### PR TITLE
Fix SSL negotiation pref

### DIFF
--- a/apps/firefox/firefox.nix
+++ b/apps/firefox/firefox.nix
@@ -251,7 +251,7 @@
         "security.remote_settings.crlite_filters.enabled" = true;
         "security.ssl.enable_ocsp_must_staple" = true;
         "security.ssl.enable_ocsp_stapling" = true;
-        "security.ssl.require_safe_negociation" = true;
+        "security.ssl.require_safe_negotiation" = true;
         "signon.autofillForms" = false;
         "signon.generation.enabled" = false;
         "signon.management.page.breach-alerts.enabled" = false;


### PR DESCRIPTION
## Summary
- fix typo in Firefox preference name `security.ssl.require_safe_negotiation`

## Testing
- `nix run nixpkgs#treefmt -- --no-cache --fail-on-change` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686811e3f4e0832c98811270378c7a44