### PR TITLE
Fix .env code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For the recipes to work properly, create a `.env` and fill it with the needed en
 
 ```
 HOST=x13
-````
+```
 
 ## Install
 


### PR DESCRIPTION
## Summary
- close the `.env` example block properly

## Testing
- `nix fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686811ef058c832cb63e80636a563db3