### PR TITLE
Add mkArmHost helper

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -246,6 +246,8 @@ let
         ++ systemModules
         ++ extraModules;
     };
+  mkArmHost = args: mkHost (args // { system = "aarch64-linux"; });
+
 in
 {
   p14s = mkHost {


### PR DESCRIPTION
## Summary
- add `mkArmHost` function to create ARM-based hosts using `mkHost`

## Testing
- `nixfmt --version` *(fails: command not found)*
- `statix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f98a6778832ca6c8ac3d287430f7