### PR TITLE
Enable Secure Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [Ephemeral file system with `impermanence` on btrfs subvolumes](./modules/impermanence/)
 - Configuration for common hardware with `nixos-hardware`
 - Automatic microcode updates for AMD CPUs with `ucodenix`
+- Secure boot with [lanzaboote](https://github.com/nix-community/lanzaboote)
 - Automatic development shells with `direnv` and `shell.nix`
 - My own custom packages including [`autoscreen`](./apps/autoscreen/) (tool to take screenshots randomly each hour) and [`mpdscrobble`](./apps/mpdscrobble/) (utility to send MPD listening history to Last.fm)
 - [`mpv` configuration with plugins](./apps/mpv/mpv.nix)

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,10 @@
     impermanence = {
       url = "github:nix-community/impermanence";
     };
+    lanzaboote = {
+      url = "github:nix-community/lanzaboote";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nix-flatpak = {
       url = "github:gmodena/nix-flatpak/?ref=latest";
     };

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -25,6 +25,11 @@ let
         ../modules/common/bootloader-systemd-boot.nix
       ];
     };
+    secureboot = {
+      system = [
+        ../modules/common/secureboot.nix
+      ];
+    };
     personal = {
       home = [
         ../apps/ledger/ledger.nix
@@ -255,6 +260,7 @@ in
       "laptop"
       "impermanence"
       "bootloader-systemd-boot"
+      "secureboot"
       "personal"
       "niri"
       "android-tools"
@@ -283,6 +289,7 @@ in
       "laptop"
       "impermanence"
       "bootloader-systemd-boot"
+      "secureboot"
       "personal"
       "gnome"
       "steam"
@@ -307,6 +314,7 @@ in
       "laptop"
       "impermanence"
       "bootloader-systemd-boot"
+      "secureboot"
       "personal"
       "niri"
       "android-tools"
@@ -330,6 +338,7 @@ in
     profiles = [
       "laptop"
       "bootloader-systemd-boot"
+      "secureboot"
       "personal"
       "niri"
       "steam"
@@ -354,6 +363,7 @@ in
     profiles = [
       "laptop"
       "bootloader-systemd-boot"
+      "secureboot"
       "niri"
       "python"
       "docker"

--- a/modules/common/secureboot.nix
+++ b/modules/common/secureboot.nix
@@ -1,0 +1,8 @@
+{ inputs, lib, ... }:
+{
+  imports = [ inputs.lanzaboote.nixosModules.lanzaboote ];
+
+  boot.lanzaboote.enable = true;
+  boot.loader.systemd-boot.enable = lib.mkForce false;
+  boot.loader.efi.canTouchEfiVariables = true;
+}


### PR DESCRIPTION
## Summary
- add lanzaboote flake input
- enable secureboot module
- include secureboot profile on systemd-boot hosts
- document secure boot in README

## Testing
- `statix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687110206ba0832c9c115bdb5a724217