### PR TITLE
Add nixos-generators image helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ just switch
 just clean
 ```
 
+To generate a bootable image for a host with `nixos-generators`:
+
+```
+just generate-image HOST install-iso
+```
+
 For the recipes to work properly, create a `.env` and fill it with the needed environment variables:
 
 ```
@@ -149,6 +155,5 @@ git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
 Some tools and utilities to test
 
 - sops-nix
-- nixos-generators
 - git-hooks
 - nh

--- a/justfile
+++ b/justfile
@@ -27,3 +27,7 @@ first-install-disko host target:
   sudo nix run 'github:nix-community/disko/latest#disko-install' -- --flake .#{{host}} --disk main {{target}} --show-trace
 
 all: update switch clean optimize
+
+generate-image host format="install-iso":
+  @echo "Generating $format image for host {{host}}"
+  ./scripts/generate-image.sh {{host}} {{format}}

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Generate a NixOS image using nixos-generators
+# Usage: ./scripts/generate-image.sh <host> [format]
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <host> [format]" >&2
+  exit 1
+fi
+
+HOST="$1"
+FORMAT="${2:-install-iso}"
+
+exec nix run github:nix-community/nixos-generators -- --flake ".#$HOST" -f "$FORMAT"


### PR DESCRIPTION
## Summary
- add a helper script using `nixos-generators`
- expose new `generate-image` recipe in justfile
- document how to generate an image and adjust TODO list

## Testing
- `nix fmt` *(fails: command not found)*
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871103ffb60832c90e0415e41ef9f7f