### PR TITLE
Integrate sops-nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - Configuration for common hardware with `nixos-hardware`
 - Automatic microcode updates for AMD CPUs with `ucodenix`
 - Automatic development shells with `direnv` and `shell.nix`
+- Secret management using [`sops-nix`](https://github.com/Mic92/sops-nix)
 - My own custom packages including [`autoscreen`](./apps/autoscreen/) (tool to take screenshots randomly each hour) and [`mpdscrobble`](./apps/mpdscrobble/) (utility to send MPD listening history to Last.fm)
 - [`mpv` configuration with plugins](./apps/mpv/mpv.nix)
 - [`nnn` configuration with plugins and bookmarks](./apps/nnn/nnn.nix)
@@ -148,7 +149,6 @@ git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
 
 Some tools and utilities to test
 
-- sops-nix
 - nixos-generators
 - git-hooks
 - nh

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,10 @@
     impermanence = {
       url = "github:nix-community/impermanence";
     };
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nix-flatpak = {
       url = "github:gmodena/nix-flatpak/?ref=latest";
     };

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -152,6 +152,11 @@ let
     pycharm = {
       home = [ ../apps/pycharm/pycharm.nix ];
     };
+    sops = {
+      system = [
+        ../modules/sops/default.nix
+      ];
+    };
   };
   mkHost =
     {
@@ -264,6 +269,7 @@ in
       "chromium"
       "mpd"
       "python"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-p14s-amd-gen4
@@ -289,6 +295,7 @@ in
       "firefox"
       "chromium"
       "python"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -315,6 +322,7 @@ in
       "chromium"
       "mpd"
       "python"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-x13-amd
@@ -338,6 +346,7 @@ in
       "mpd"
       "python"
       "obs"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -360,6 +369,7 @@ in
       "neovim-nvf"
       "firefox"
       "vscode"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -387,6 +397,7 @@ in
       "steam"
       "firefox"
       "chromium"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-amd
@@ -413,6 +424,7 @@ in
       "mpd"
       "firefox"
       "chromium"
+      "sops"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-x200s

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -1,0 +1,10 @@
+{ inputs, ... }:
+{
+  imports = [ inputs.sops-nix.nixosModules.sops ];
+
+  sops.age = {
+    # generate a new age key if none exists
+    generateKey = true;
+    keyFile = "/var/lib/sops-nix/key.txt";
+  };
+}


### PR DESCRIPTION
## Summary
- add sops-nix flake input
- configure sops with an age key
- enable new `sops` profile on all hosts
- document secret management with sops-nix

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871102f95c0832c81a7d315a5455598