### PR TITLE
Add advanced Nix tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@
 - Configuration for common hardware with `nixos-hardware`
 - Automatic microcode updates for AMD CPUs with `ucodenix`
 - Automatic development shells with `direnv` and `shell.nix`
+- Fast package lookup with `nix-index` and command-not-found integration
+- Ability to run unpatched binaries thanks to `nix-ld`
+- Helpful `nh` CLI for managing Nix generations
 - My own custom packages including [`autoscreen`](./apps/autoscreen/) (tool to take screenshots randomly each hour) and [`mpdscrobble`](./apps/mpdscrobble/) (utility to send MPD listening history to Last.fm)
 - [`mpv` configuration with plugins](./apps/mpv/mpv.nix)
 - [`nnn` configuration with plugins and bookmarks](./apps/nnn/nnn.nix)
@@ -151,4 +154,3 @@ Some tools and utilities to test
 - sops-nix
 - nixos-generators
 - git-hooks
-- nh

--- a/apps/nix-index/default.nix
+++ b/apps/nix-index/default.nix
@@ -1,0 +1,9 @@
+{
+  programs.nix-index = {
+    enable = true;
+    enableBashIntegration = true;
+    enableFishIntegration = true;
+    enableZshIntegration = true;
+  };
+  programs.command-not-found.enable = true;
+}

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -152,6 +152,10 @@ let
     pycharm = {
       home = [ ../apps/pycharm/pycharm.nix ];
     };
+    nix-tools = {
+      system = [ ../modules/common/nix-ld.nix ];
+      home = [ ../apps/nix-index/default.nix ];
+    };
   };
   mkHost =
     {
@@ -264,6 +268,7 @@ in
       "chromium"
       "mpd"
       "python"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-p14s-amd-gen4
@@ -289,6 +294,7 @@ in
       "firefox"
       "chromium"
       "python"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -315,6 +321,7 @@ in
       "chromium"
       "mpd"
       "python"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-x13-amd
@@ -338,6 +345,7 @@ in
       "mpd"
       "python"
       "obs"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -360,6 +368,7 @@ in
       "neovim-nvf"
       "firefox"
       "vscode"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-intel
@@ -387,6 +396,7 @@ in
       "steam"
       "firefox"
       "chromium"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-amd
@@ -413,6 +423,7 @@ in
       "mpd"
       "firefox"
       "chromium"
+      "nix-tools"
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.lenovo-thinkpad-x200s

--- a/hosts/home-manager-common-config.nix
+++ b/hosts/home-manager-common-config.nix
@@ -36,6 +36,7 @@
     imagemagick
     jq
     just
+    nh
     keepassxc
     libreoffice-fresh
     ncdu

--- a/modules/common/nix-ld.nix
+++ b/modules/common/nix-ld.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  programs.nix-ld = {
+    enable = true;
+    package = pkgs.nix-ld-rs;
+    libraries = with pkgs; [
+      stdenv.cc.cc
+      zlib
+      openssl
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- add `nix-index` module and enable command-not-found integration
- add `nix-ld` system module
- include `nh` command in common packages
- provide `nix-tools` profile and use it on all hosts
- document the new tools

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687110192824832c9360675f7ab19dfc