### PR TITLE
Update SG13 configuration for RTX 3070

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - **vaio**: Sony Vaio Pro PK13 (Intel Core i5-1035G1, 16GB RAM, niri)
 - **x13**: Lenovo ThinkPad X13 Gen 1 (AMD Ryzen 5 4650U, 16GB RAM, niri, impermanence)
 - **x1yoga**: Lenovo ThinkPad X1 Yoga Gen 5 (Intel Core i5-10210U, 8GB RAM, hyprland + touch gestures w/ hyprgrass, impermanence)
-- **sg13**: Silverstone SG13 (AMD Ryzen 5 2600, RX 580 8GB, 16GB RAM, gnome)
+- **sg13**: Silverstone SG13 (AMD Ryzen 5 2600, RTX 3070, 16GB RAM, gnome)
 - **x61s**: Lenovo Thinkpad X61s (Intel Core 2 Duo L7500, 3GB RAM, sway)
 - **latitude**: Dell Latitude 7420 (Intel Core i7 1165G7, 16GB RAM, hyprland)
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -414,7 +414,8 @@ in
     ];
     extraModules = [
       inputs.nixos-hardware.nixosModules.common-cpu-amd
-      inputs.nixos-hardware.nixosModules.common-gpu-amd
+      inputs.nixos-hardware.nixosModules.common-gpu-nvidia-nonprime
+      (inputs.nixos-hardware + "/common/gpu/nvidia/ampere")
       {
         my.stylix.wallpaper = "hk-plant";
       }


### PR DESCRIPTION
## Summary
- swap SG13 GPU to Nvidia RTX 3070
- configure Nvidia modules for the SG13 host

## Testing
- `nix fmt` *(fails: unable to download from cache.nixos.org)*

------
https://chatgpt.com/codex/tasks/task_e_6888b4cfca2c832cb7e2ad4bdadc097f