### PR TITLE
Disable hyprlock fingerprint on vaio

### DIFF
--- a/hosts/vaio/home.nix
+++ b/hosts/vaio/home.nix
@@ -1,8 +1,4 @@
-{
-  pkgs,
-  lib,
-  ...
-}:
+{ pkgs, lib, ... }:
 {
   home.packages = with pkgs; [
     audacity
@@ -12,4 +8,8 @@
   ];
 
   programs.niri.settings.outputs."Dell Inc. DELL S2721DGF 6C1TR83".mode.refresh = lib.mkForce 59.951;
+
+  # Disable fingerprint authentication in hyprlock to avoid
+  # wake-from-sleep issues on the VAIO host.
+  programs.hyprlock.settings.auth.fingerprint.enabled = lib.mkForce false;
 }


### PR DESCRIPTION
## Summary
- disable fingerprint auth in hyprlock on vaio to avoid resume issues

## Testing
- `nix fmt`
- `nix flake check` *(fails: building full system was aborted due to resource constraints)*

------
https://chatgpt.com/codex/tasks/task_e_688e2f2de100832c924cc323961a70b8