### PR TITLE
feat: add sops-nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+secrets/age.key
+secrets/keys.txt

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,10 @@
+# SOPS configuration for nixos-config
+# Replace age1example... with your actual Age public key
+keys:
+  - &main age1exampleexampleexampleexamplexxxxxxxxxxxxxxxxxxxx
+
+creation_rules:
+  - path_regex: secrets/.*\.(yaml|yml|json|env)$
+    key_groups:
+      - age:
+          - *main

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - Configuration for common hardware with `nixos-hardware`
 - Automatic microcode updates for AMD CPUs with `ucodenix`
 - Automatic development shells with `direnv` and `shell.nix`
+- Secrets management with [`sops-nix`](https://github.com/Mic92/sops-nix)
 - My own custom packages including [`autoscreen`](./apps/autoscreen/) (tool to take screenshots randomly each hour) and [`mpdscrobble`](./apps/mpdscrobble/) (utility to send MPD listening history to Last.fm)
 - [`mpv` configuration with plugins](./apps/mpv/mpv.nix)
 - [`nnn` configuration with plugins and bookmarks](./apps/nnn/nnn.nix)
@@ -91,6 +92,51 @@ For the recipes to work properly, create a `.env` and fill it with the needed en
 ```
 HOST=x13
 ```
+
+## Secrets management with sops-nix
+
+This configuration can manage secrets with [sops-nix](https://github.com/Mic92/sops-nix). All secrets are stored encrypted in the `secrets/` directory and decrypted during activation.
+
+### Generate an Age key
+
+Create an Age key pair and keep the private key outside the repository:
+
+```
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+Copy the printed public key and replace the placeholder in [`.sops.yaml`](./.sops.yaml).
+
+### Encrypt secrets
+
+Add or edit your encrypted secrets file:
+
+```
+mkdir -p secrets
+sops secrets/secrets.yaml
+```
+
+Example structure:
+
+```yaml
+ssh:
+  id_ed25519: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+nextcloud:
+  password: my-password
+```
+
+Save and commit the encrypted file. Only the private Age key must remain uncommitted.
+
+### Use secrets in the system
+
+Enable the `secrets` profile for a host in `hosts/default.nix`. The module installs the secrets at runtime:
+
+* `ssh/id_ed25519` → `~/.ssh/id_ed25519`
+* `nextcloud/password` → `~/.config/nextcloud/credentials`
+
+Additional secrets can be added to `secrets/secrets.yaml` following the same pattern.
 
 ## Install
 
@@ -148,7 +194,6 @@ git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
 
 Some tools and utilities to test
 
-- sops-nix
 - nixos-generators
 - git-hooks
 - nh

--- a/flake.lock
+++ b/flake.lock
@@ -1069,6 +1069,7 @@
         "nur": "nur",
         "nvf": "nvf",
         "search": "search",
+        "sops-nix": "sops-nix",
         "stylix": "stylix",
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix",
@@ -1097,6 +1098,26 @@
       "original": {
         "owner": "nuschtos",
         "repo": "search",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754328224,
+        "narHash": "sha256-glPK8DF329/dXtosV7YSzRlF4n35WDjaVwdOMEoEXHA=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "49021900e69812ba7ddb9e40f9170218a7eca9f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,10 @@
     impermanence = {
       url = "github:nix-community/impermanence";
     };
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nix-flatpak = {
       url = "github:gmodena/nix-flatpak/?ref=latest";
     };

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -35,6 +35,11 @@ let
         ../modules/common/openssh-server.nix
       ];
     };
+    secrets = {
+      system = [
+        ../modules/common/sops.nix
+      ];
+    };
     personal = {
       home = [
         ../apps/ledger/ledger.nix

--- a/modules/common/sops.nix
+++ b/modules/common/sops.nix
@@ -1,0 +1,45 @@
+{
+  pkgs,
+  inputs,
+  lib,
+  user,
+  ...
+}:
+let
+  ageKeyFile = "/home/${user}/.config/sops/age/keys.txt";
+  secretsFile = ../../secrets/secrets.yaml;
+  hasAgeKey = builtins.pathExists ageKeyFile;
+  hasSecrets = builtins.pathExists secretsFile;
+in
+{
+    imports = lib.optional hasAgeKey inputs.sops-nix.nixosModules.sops;
+
+    environment.systemPackages = with pkgs; [
+      sops
+      age
+      ssh-to-age
+    ];
+  }
+  // lib.optionalAttrs hasAgeKey {
+    sops = {
+      age.keyFile = ageKeyFile;
+    }
+    // lib.optionalAttrs hasSecrets {
+      defaultSopsFile = secretsFile;
+      secrets = {
+        "ssh/id_ed25519" = {
+          path = "/home/${user}/.ssh/id_ed25519";
+          format = "binary";
+          owner = user;
+          group = "users";
+          mode = "0600";
+        };
+        "nextcloud/password" = {
+          path = "/home/${user}/.config/nextcloud/credentials";
+          owner = user;
+          group = "users";
+          mode = "0600";
+        };
+      };
+    };
+  }


### PR DESCRIPTION
## Summary
- add sops-nix flake input and secrets module for age-encrypted files
- document how to create and use encrypted secrets
- include sample .sops.yaml and ignore local key material

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: cannot download photo-1672491441167-1daa7c3c95a8: error 403)*

------
https://chatgpt.com/codex/tasks/task_e_689871b3dd88832cb450eca0cfd9db50