### PR TITLE
Ensure Firefox announces dark color scheme

### DIFF
--- a/apps/firefox/firefox.nix
+++ b/apps/firefox/firefox.nix
@@ -180,6 +180,8 @@
         "browser.tabs.insertAfterCurrent" = true;
         "browser.tabs.loadBookmarksInBackground" = true;
         "browser.tabs.tabmanager.enabled" = false;
+        "browser.theme.content-theme" = 2;
+        "browser.theme.toolbar-theme" = 2;
         "browser.toolbars.bookmarks.visibility" = "never";
         "browser.translation.neverForLanguages" = "fr";
         "browser.uidensity" = 1;
@@ -188,6 +190,7 @@
         "browser.urlbar.suggest.topsites" = false;
         "browser.urlbar.trimURLS" = false;
         "browser.urlbar.unitConversion.enabled" = true;
+        "layout.css.prefers-color-scheme.content-override" = 2;
         "dom.battery.enabled" = false;
         "dom.enable_web_task_scheduling" = true;
         "dom.event.clipboardevents.enabled" = false;


### PR DESCRIPTION
## Summary
- configure Firefox to use the dark variants for toolbar and web content
- advertise a dark `prefers-color-scheme` override so sites automatically use dark themes

## Testing
- `nix run .#treefmt` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c897435384832c9dd01fa258ca166d