### PR TITLE
Configure GNOME Alt-Tab to cycle through windows

### DIFF
--- a/apps/gnome/gnome.nix
+++ b/apps/gnome/gnome.nix
@@ -44,6 +44,12 @@ with lib.hm.gvariant;
     "org/gnome/desktop/wm/preferences" = {
       button-layout = "appmenu:minimize,maximize,close";
     };
+    "org/gnome/desktop/wm/keybindings" = {
+      "switch-applications" = [ ];
+      "switch-applications-backward" = [ ];
+      "switch-windows" = [ "<Alt>Tab" ];
+      "switch-windows-backward" = [ "<Alt><Shift>Tab" ];
+    };
     "org/gnome/desktop/session" = {
       idle-delay = mkUint32 0;
     };


### PR DESCRIPTION
## Summary
- update the GNOME keybinding configuration so Alt-Tab switches between individual windows instead of grouped applications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6ed2f928832ca8e8768875205971