### PR TITLE
Configure ungoogled Chromium extensions and search

### DIFF
--- a/apps/ungoogled-chromium/ungoogled-chromium.nix
+++ b/apps/ungoogled-chromium/ungoogled-chromium.nix
@@ -1,4 +1,33 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
+let
+  extensionIds = [
+    "oboonakemofpalcgghocfoadofidjkkk" # KeePassXC-Browser
+    "dbepggeogbaibhgnhhndojpepiihcmeb" # Vimium
+    "ddkjiahejlhfcafbddmgiahcphecmpfh" # uBlock Origin Lite
+  ];
+  extensionUpdateUrl = "https://clients2.google.com/service/update2/crx";
+  chromiumConfigDir = "${config.xdg.configHome}/chromium";
+  managedPolicies = {
+    ExtensionInstallAllowlist = extensionIds;
+    ExtensionInstallForcelist =
+      builtins.map (id: "${id};${extensionUpdateUrl}") extensionIds;
+    DefaultSearchProviderEnabled = true;
+    DefaultSearchProviderName = "DuckDuckGo";
+    DefaultSearchProviderKeyword = "DuckDuckGo";
+    DefaultSearchProviderSearchURL = "https://duckduckgo.com/?q={searchTerms}";
+    DefaultSearchProviderSuggestURL =
+      "https://duckduckgo.com/ac/?q={searchTerms}&type=list";
+    DefaultSearchProviderIconURL = "https://duckduckgo.com/favicon.ico";
+  };
+in
 {
-  home.packages = with pkgs; [ ungoogled-chromium ];
+  programs.chromium = {
+    enable = true;
+    package = pkgs.ungoogled-chromium;
+    commandLineArgs = [ "--enable-extensions" ];
+    extensions = builtins.map (id: { inherit id; }) extensionIds;
+  };
+
+  home.file."${chromiumConfigDir}/policies/managed/extensions.json".text =
+    builtins.toJSON managedPolicies;
 }


### PR DESCRIPTION
## Summary
- enable the Chromium Home Manager module for ungoogled-chromium with extension support
- preinstall KeePassXC-Browser, Vimium, and uBlock Origin Lite and enforce DuckDuckGo as the default search engine

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6f15175c832cbed29ddc3124c46d