### PR TITLE
Enable graphical session target for GNOME profile

### DIFF
--- a/apps/gnome/gnome.nix
+++ b/apps/gnome/gnome.nix
@@ -1,6 +1,11 @@
 { pkgs, lib, ... }:
 with lib.hm.gvariant;
 {
+  # Ensure user services that hook into graphical-session.target (for example
+  # the Nextcloud client) are started automatically when the GNOME session
+  # comes up.
+  systemd.user.enableGraphicalSession = true;
+
   home.packages = with pkgs; [
     gnome-tweaks
     gnomeExtensions.no-overview


### PR DESCRIPTION
## Summary
- enable the graphical session target for the GNOME home profile so user services hook into the session correctly
- add a note explaining this is needed for services like the Nextcloud client to autostart

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68dea11f24f0832cb9d597bb438f9854