### PR TITLE
Enhance MangoHud overlay metrics

### DIFF
--- a/apps/steam/steam.nix
+++ b/apps/steam/steam.nix
@@ -6,9 +6,16 @@
       horizontal = true;
       battery = true;
       cpu_stats = true;
-      gpu_stats = true;
+      cpu_load = true;
+      cpu_temp = true;
       cpu_power = true;
+      gpu_stats = true;
+      gpu_load = true;
+      gpu_temp = true;
+      gpu_core_clock = true;
+      gpu_mem_clock = true;
       gpu_power = true;
+      vram = true;
       ram = true;
       fps = true;
       table_columns = 14;


### PR DESCRIPTION
## Summary
- enable MangoHud VRAM usage display
- surface additional CPU and GPU telemetry (load, temperature, memory clocks) for a more informative overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deef562a2c832c8bfffd07419bc69a