### PR TITLE
Tune sg13 power profiles

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -469,6 +469,9 @@ in
         my.stylix.wallpaper = "hk-plant";
       }
     ];
+    extraHomeModules = [
+      ../apps/codex/codex.nix
+    ];
   };
   x61s = mkHost {
     hostName = "x61s";

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -464,6 +464,7 @@ in
       inputs.nixos-hardware.nixosModules.common-cpu-amd
       inputs.nixos-hardware.nixosModules.common-gpu-nvidia-nonprime
       (inputs.nixos-hardware + "/common/gpu/nvidia/ampere")
+      ../hosts/sg13/default.nix
       {
         my.stylix.wallpaper = "hk-plant";
       }

--- a/hosts/sg13/default.nix
+++ b/hosts/sg13/default.nix
@@ -5,9 +5,6 @@
 }:
 let
   gpuPowerLimitWatts = 180;
-  pptLimitWatts = 88;
-  tdcLimitAmps = 60;
-  edcLimitAmps = 90;
 
   nvidiaPowerLimitScript = pkgs.writeShellScript "sg13-nvidia-power-limit" ''
     #!${pkgs.bash}/bin/bash
@@ -33,39 +30,14 @@ let
     /run/current-system/sw/bin/nvidia-smi -pl ${toString gpuPowerLimitWatts}
   '';
 
-  ryzenEcoScript = pkgs.writeShellScript "sg13-ryzen-eco" ''
-    #!${pkgs.bash}/bin/bash
-    set -euo pipefail
-
-    ${lib.getExe pkgs.ryzenadj} \
-      --ppt-limit=${toString pptLimitWatts} \
-      --tdc-limit=${toString tdcLimitAmps} \
-      --edc-limit=${toString edcLimitAmps} \
-      --coall=-15
-  '';
-
 in
 {
-  environment.systemPackages = [ pkgs.ryzenadj ];
-
-  boot.kernelModules = [ "msr" ];
-
   systemd.services.sg13-nvidia-power-limit = {
     description = "Set NVIDIA GPU power limit for sg13";
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
       Type = "oneshot";
       ExecStart = nvidiaPowerLimitScript;
-      RemainAfterExit = true;
-    };
-  };
-
-  systemd.services.sg13-ryzen-eco = {
-    description = "Apply Ryzen 5950X eco tuning";
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = ryzenEcoScript;
       RemainAfterExit = true;
     };
   };

--- a/hosts/sg13/default.nix
+++ b/hosts/sg13/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  gpuPowerLimitWatts = 180;
+  pptLimitWatts = 88;
+  tdcLimitAmps = 60;
+  edcLimitAmps = 90;
+
+  nvidiaPowerLimitScript = pkgs.writeShellScript "sg13-nvidia-power-limit" ''
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+
+    if [ ! -x /run/current-system/sw/bin/nvidia-smi ]; then
+      exit 0
+    fi
+
+    # Give the NVIDIA persistence daemon a moment to come up before we try to
+    # change power management settings so that the command does not fail when
+    # the driver is still initialising at boot.
+    for attempt in 1 2 3 4 5; do
+      if /run/current-system/sw/bin/nvidia-smi -pm 1; then
+        break
+      fi
+      if [ "${attempt}" -eq 5 ]; then
+        exit 1
+      fi
+      sleep 2
+    done
+
+    /run/current-system/sw/bin/nvidia-smi -pl ${toString gpuPowerLimitWatts}
+  '';
+
+  ryzenEcoScript = pkgs.writeShellScript "sg13-ryzen-eco" ''
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+
+    ${lib.getExe pkgs.ryzenadj} \
+      --ppt-limit=${toString pptLimitWatts} \
+      --tdc-limit=${toString tdcLimitAmps} \
+      --edc-limit=${toString edcLimitAmps} \
+      --coall=-15
+  '';
+
+in
+{
+  environment.systemPackages = [ pkgs.ryzenadj ];
+
+  boot.kernelModules = [ "msr" ];
+
+  systemd.services.sg13-nvidia-power-limit = {
+    description = "Set NVIDIA GPU power limit for sg13";
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = nvidiaPowerLimitScript;
+      RemainAfterExit = true;
+    };
+  };
+
+  systemd.services.sg13-ryzen-eco = {
+    description = "Apply Ryzen 5950X eco tuning";
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = ryzenEcoScript;
+      RemainAfterExit = true;
+    };
+  };
+}

--- a/hosts/sg13/default.nix
+++ b/hosts/sg13/default.nix
@@ -24,7 +24,7 @@ let
       if /run/current-system/sw/bin/nvidia-smi -pm 1; then
         break
       fi
-      if [ "${attempt}" -eq 5 ]; then
+      if [ "$attempt" -eq 5 ]; then
         exit 1
       fi
       sleep 2

--- a/hosts/sg13/hardware-configuration.nix
+++ b/hosts/sg13/hardware-configuration.nix
@@ -47,4 +47,8 @@
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  boot.kernelParams = [ "amd_pstate=guided" ];
+  powerManagement.enable = true;
+  powerManagement.cpuFreqGovernor = "schedutil";
 }


### PR DESCRIPTION
## Summary
- add a host-specific module for sg13 that caps the RTX 3070 at 180 W and applies a Ryzen 5950X eco tuning profile
- enable the sg13 module in the host definition so the power limits are configured at boot

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e11a44f348832ca2c6451f6cf66d72