### PR TITLE
Stop enabling CA derivations in Nix configuration

### DIFF
--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -147,12 +147,13 @@
   # services.openssh.enable = true;
 
   nix = {
-    extraOptions = ''
-      experimental-features = nix-command flakes ca-derivations
-      keep-outputs = true
-      keep-derivations = true
-    '';
     settings = {
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+      keep-outputs = true;
+      keep-derivations = true;
       substituters = [
         "https://cache.nixos.org"
       ];


### PR DESCRIPTION
## Summary
- remove the ca-derivations experimental feature so Nix can reuse upstream binaries
- move keep-outputs and keep-derivations into nix.settings for better structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e685b3473c832caf45f9ba5cd6997a