### PR TITLE
deploy-rs: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,6 +118,32 @@
         "type": "github"
       }
     },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": [
+          "flake-utils"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766051518,
+        "narHash": "sha256-znKOwPXQnt3o7lDb3hdf19oDo0BLP4MfBOYiWkEHoik=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "d5eff7f948535b9c723d60cd8239f8f11ddc90fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
@@ -1085,6 +1111,7 @@
     "root": {
       "inputs": {
         "base16": "base16",
+        "deploy-rs": "deploy-rs",
         "devshell": "devshell",
         "disko": "disko",
         "flake-compat": "flake-compat",

--- a/flake.nix
+++ b/flake.nix
@@ -276,57 +276,67 @@
       };
 
       # deploy-rs configuration for remote deployments
-      deploy.nodes = {
-        nixos-kimsufi-01 = {
-          hostname = "10.10.20.10";
-          sshUser = "root";
-          sshOpts = [
-            "-J"
-            "kimsufi"
-          ];
-          profiles.system = {
-            user = "root";
-            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-01;
-            magicRollback = true;
-            autoRollback = true;
-            activationTimeout = 300;
-            confirmTimeout = 60;
+      deploy.nodes =
+        let
+          # Helper to create a deploy node configuration for a host
+          mkDeployNode =
+            {
+              hostName,
+              hostname,
+              sshUser ? "root",
+              sshOpts ? [ ],
+              user ? "root",
+              magicRollback ? true,
+              autoRollback ? true,
+              activationTimeout ? 300,
+              confirmTimeout ? 60,
+            }:
+            let
+              hostConfig = self.nixosConfigurations.${hostName};
+              # Derive system architecture from the nixosConfiguration
+              inherit (hostConfig.pkgs) system;
+            in
+            {
+              inherit hostname sshUser sshOpts;
+              profiles.system = {
+                inherit
+                  user
+                  magicRollback
+                  autoRollback
+                  activationTimeout
+                  confirmTimeout
+                  ;
+                path = inputs.deploy-rs.lib.${system}.activate.nixos hostConfig;
+              };
+            };
+        in
+        {
+          nixos-kimsufi-01 = mkDeployNode {
+            hostName = "nixos-kimsufi-01";
+            hostname = "10.10.20.10";
+            sshOpts = [
+              "-J"
+              "kimsufi"
+            ];
           };
-        };
 
-        nixos-kimsufi-02 = {
-          hostname = "10.10.20.11";
-          sshUser = "root";
-          sshOpts = [
-            "-J"
-            "kimsufi"
-          ];
-          profiles.system = {
-            user = "root";
-            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-02;
-            magicRollback = true;
-            autoRollback = true;
-            activationTimeout = 300;
-            confirmTimeout = 60;
+          nixos-kimsufi-02 = mkDeployNode {
+            hostName = "nixos-kimsufi-02";
+            hostname = "10.10.20.11";
+            sshOpts = [
+              "-J"
+              "kimsufi"
+            ];
           };
-        };
 
-        nixos-kimsufi-03 = {
-          hostname = "10.10.20.12";
-          sshUser = "root";
-          sshOpts = [
-            "-J"
-            "kimsufi"
-          ];
-          profiles.system = {
-            user = "root";
-            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-03;
-            magicRollback = true;
-            autoRollback = true;
-            activationTimeout = 300;
-            confirmTimeout = 60;
+          nixos-kimsufi-03 = mkDeployNode {
+            hostName = "nixos-kimsufi-03";
+            hostname = "10.10.20.12";
+            sshOpts = [
+              "-J"
+              "kimsufi"
+            ];
           };
         };
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,14 @@
         systems.follows = "systems";
       };
     };
+    deploy-rs = {
+      url = "github:serokell/deploy-rs";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        utils.follows = "flake-utils";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
     gitignore = {
       url = "github:hercules-ci/gitignore.nix";
       inputs = {
@@ -242,6 +250,7 @@
             };
           };
         }
+        // (inputs.deploy-rs.lib.${system}.deployChecks self.deploy)
       );
 
       devShells = eachSystem (system: {
@@ -264,6 +273,60 @@
           user
           ;
         inherit (nixpkgs) lib;
+      };
+
+      # deploy-rs configuration for remote deployments
+      deploy.nodes = {
+        nixos-kimsufi-01 = {
+          hostname = "10.10.20.10";
+          sshUser = "root";
+          sshOpts = [
+            "-J"
+            "kimsufi"
+          ];
+          profiles.system = {
+            user = "root";
+            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-01;
+            magicRollback = true;
+            autoRollback = true;
+            activationTimeout = 300;
+            confirmTimeout = 60;
+          };
+        };
+
+        nixos-kimsufi-02 = {
+          hostname = "10.10.20.11";
+          sshUser = "root";
+          sshOpts = [
+            "-J"
+            "kimsufi"
+          ];
+          profiles.system = {
+            user = "root";
+            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-02;
+            magicRollback = true;
+            autoRollback = true;
+            activationTimeout = 300;
+            confirmTimeout = 60;
+          };
+        };
+
+        nixos-kimsufi-03 = {
+          hostname = "10.10.20.12";
+          sshUser = "root";
+          sshOpts = [
+            "-J"
+            "kimsufi"
+          ];
+          profiles.system = {
+            user = "root";
+            path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nixos-kimsufi-03;
+            magicRollback = true;
+            autoRollback = true;
+            activationTimeout = 300;
+            confirmTimeout = 60;
+          };
+        };
       };
     };
 }

--- a/justfile
+++ b/justfile
@@ -32,8 +32,13 @@ install-proxmox-vm-kimsufi hostname ip:
   @echo "  ssh -J kimsufi nixos@{{ip}}"
   @echo "  bash /tmp/install-nixos.sh {{hostname}}"
 
+deploy-kimsufi:
+  @echo "Deploying all kimsufi VMs in parallel with auto-rollback..."
+  deploy . -- --targets '.#nixos-kimsufi-01' '.#nixos-kimsufi-02' '.#nixos-kimsufi-03'
+
 switch-proxmox-vm-kimsufi hostname ip:
   @echo "Deploying config for {{hostname}} to {{ip}} via kimsufi jump host"
+  @echo "WARNING: Consider using 'just deploy-kimsufi' instead for auto-rollback safety"
   NIX_SSHOPTS="-J kimsufi" nixos-rebuild switch --flake .#{{hostname}} --target-host {{ip}} --sudo --ask-sudo-password
 
 clean:


### PR DESCRIPTION
This pull request introduces deploy-rs for streamlined and safer remote deployments to the kimsufi NixOS VMs. It adds the required flake input, configures deployment targets with rollback options, and provides a new convenience command for deploying to all VMs in parallel.

**Deploy-rs integration and configuration:**

* Added `deploy-rs` as a flake input in `flake.nix`, following relevant dependencies for compatibility.
* Defined `deploy.nodes` in `flake.nix` for three kimsufi hosts (`nixos-kimsufi-01`, `nixos-kimsufi-02`, `nixos-kimsufi-03`), specifying SSH jump host, deployment profiles, and enabling automatic rollback and timeouts for safer deployments.
* Integrated deploy-rs deployment checks into the checks output for CI or local validation.

**Developer workflow improvements:**

* Added a `deploy-kimsufi` command to the `justfile` for parallel deployment to all kimsufi VMs with deploy-rs, highlighting auto-rollback safety.
* Updated messaging in the legacy `switch-proxmox-vm-kimsufi` command to recommend using the new deploy-rs-based workflow.