### PR TITLE
fix(zen-browser): replace transparent-zen with patched version that respects ignore list

### DIFF
--- a/apps/zen-browser/transparent-zen-patched.nix
+++ b/apps/zen-browser/transparent-zen-patched.nix
@@ -1,0 +1,63 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  nodejs,
+  zip,
+}:
+
+let
+  version = "0.9.4-patched-1";
+in
+buildNpmPackage {
+  pname = "transparent-zen";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "dbeley";
+    repo = "transparent-zen";
+    rev = "fix/respect-ignore-list-on-styles-injection";
+    hash = "sha256-P9B6Q9PuHLTDj12DSYAEqv/4p3ijI5la1EsQSLFqPMU=";
+  };
+
+  npmDepsHash = "sha256-kaQMGFZgNFihglS8J492xdqxiu3FB+q83cXz+gQIMMc=";
+
+  nativeBuildInputs = [
+    nodejs
+    zip
+  ];
+
+  # Disable the npm build hook — we handle building ourselves
+  dontNpmBuild = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Build the extension (skip vue-tsc type check, just vite)
+    npx vite build
+
+    # Package as XPI — preserve dist/ prefix to match manifest.json paths
+    cd "$NIX_BUILD_TOP/source"
+    ${zip}/bin/zip -r "$TMPDIR/transparent-zen.xpi" \
+      dist/ styles/ assets/ data/ manifest.json \
+      -x 'dist/*.map' > /dev/null
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 "$TMPDIR/transparent-zen.xpi" \
+      "$out/share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/transparent-zen.xpi"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Applies custom styles to make your favorite websites transparent (patched to respect ignore list on tab switch)";
+    homepage = "https://github.com/dbeley/transparent-zen";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+}

--- a/modules/overlays.nix
+++ b/modules/overlays.nix
@@ -11,6 +11,17 @@
   nixpkgs.overlays = [
     inputs.niri-nix.overlays.niri-nix
     inputs.nur.overlays.default
+    (final: prev: {
+      nur = prev.nur // {
+        repos = prev.nur.repos // {
+          rycee = prev.nur.repos.rycee // {
+            firefox-addons = prev.nur.repos.rycee.firefox-addons // {
+              transparent-zen = final.callPackage ../apps/zen-browser/transparent-zen-patched.nix { };
+            };
+          };
+        };
+      };
+    })
     # (_: super: {
     # # to fix zoom memory leak, working version found here https://github.com/NixOS/nixpkgs/pull/361097
     # zoom-us = super.zoom-us.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
The upstream transparent-zen addon has a bug where blacklisted tabs (in the ignore list) still get transparency styles applied when switching tabs. This happens because the background script (`applyStyles`) injects CSS into **all** tabs in the current window, ignoring the blacklist.

This PR replaces the NUR transparent-zen package with a version built from a [patched fork](https://github.com/dbeley/transparent-zen/tree/fix/respect-ignore-list-on-styles-injection) containing two fixes:

### Fix 1 — Background script (`applyStyles`)
When injecting `dynamic-transparency.css` globally (no specific domains targetted), the background script now reads the extension settings and checks each tab's hostname against `blacklistedDomains`. Tabs whose domain is in the ignore list are skipped (or only included if in whitelist mode).

### Fix 2 — Content script (`updateSettings` handler)
When the user adds a domain to the ignore list from the settings page, an `updateSettings` message is sent but there was no handler for it. Now the content script re-evaluates and removes transparency styles from tabs that should no longer have them — no manual reload needed.

### Changes
- `apps/zen-browser/transparent-zen-patched.nix` — builds the patched extension from source using `buildNpmPackage`
- `modules/overlays.nix` — overlay replaces `nur.repos.rycee.firefox-addons.transparent-zen` with the patched version, affecting both Firefox and Zen Browser