### PR TITLE
hermes-webui: disable gateway service to fix 409 approval relay errors

### DIFF
--- a/apps/hermes-server/home.nix
+++ b/apps/hermes-server/home.nix
@@ -1,6 +1,7 @@
 {
   services.hermes-webui = {
     enable = true;
+    enableGateway = false;
     port = 80;
     passwordFile = "$HOME/.config/hermes/webui-password";
   };


### PR DESCRIPTION
## Summary

Disables the `hermes-gateway` systemd user service on the hermes-server profile. This service is enabled by default in the `hermes-webui-nix` flake module but causes HTTP 409 errors when trying to approve tool calls from the WebUI.

## Problem

The `hermes-gateway` service runs `hermes gateway run` as a background process. When it needs tool approval, it creates "gateway mirror" entries in the WebUI approval queue. However, the WebUI runs in **legacy mode** (in-process agent) — there is no active gateway run ID (`_STREAM_RUN_IDS` is empty) to relay the approval decision back to. Result: clicking approve/deny returns HTTP 409 with:
> *"Gateway approval could not be relayed because the active run is unavailable."*

## Fix

Added `enableGateway = false` to `apps/hermes-server/home.nix`. This stops the unnecessary gateway service — the in-process agent handles approvals directly as it did before the hermes-webui-nix migration. Cron/scheduling still works through the in-process scheduler; the gateway is only needed for messaging platform integrations (Telegram, Discord, etc.).

## Changes

| File | Change |
|---|---|
| `apps/hermes-server/home.nix` | Added `enableGateway = false` to the hermes-webui service config |
