### PR TITLE
fix(hermes-server): update hermes-webui-nix flake lock for gateway fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782409006,
-        "narHash": "sha256-hiiQZ9tllh9j/3fuoelA9fO/qgMUnuT7Gmh7hbSOFow=",
+        "lastModified": 1782414060,
+        "narHash": "sha256-RdEKwqCLRA20yyj5RK5f8YreP4NBjZr8uQibCtZtQrc=",
         "owner": "dbeley",
         "repo": "hermes-webui-nix",
-        "rev": "69488be9a7a5179aa210e3f9ec427e6d3a3e9934",
+        "rev": "1c3e77ddf64f0d7db6787b16193badfa8bc7013c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Context

[hermes-webui-nix PR #3](https://github.com/dbeley/hermes-webui-nix/pull/3) (merged) moved the Hermes Gateway systemd unit definition from the home-manager module into the NixOS system module, so it gets deployed on `nixos-rebuild switch` regardless of home-manager activation state.

## Changes

Only the `flake.lock` is updated — no config file changes needed because all new options have sensible defaults:

| New option | Default | Effect |
|---|---|---|
| `services.hermes-webui.enableGateway` | `true` | Gateway service deployed automatically |
| `services.hermes-webui.agentPackage` | `llm-agents.hermes-agent` | Resolved from the existing flake input |

## After merging

Run `nixos-rebuild switch --flake .#nixos-era-01` to deploy the new gateway unit. Then remove the manually-installed unit (created by a prior `hermes gateway install` recovery):

```
rm /home/david/.config/systemd/user/hermes-gateway.service
systemctl --user daemon-reload
```

The gateway will now survive future `nix flake update` runs.