### PR TITLE
swayimg: add Shift+Delete shortcut to delete current image

### DIFF
--- a/apps/swayimg/swayimg.nix
+++ b/apps/swayimg/swayimg.nix
@@ -86,6 +86,14 @@
     swayimg.viewer.on_key("q", function()
       swayimg.exit()
     end)
+    swayimg.viewer.on_key("S-Delete", function()
+      local image = swayimg.viewer.get_image()
+      if image then
+        os.remove(image.path)
+        swayimg.text.set_status("Deleted: " .. image.path)
+        swayimg.viewer.switch_image("next")
+      end
+    end)
 
     -- Key bindings - gallery mode
     swayimg.gallery.on_key("h", function()
@@ -99,6 +107,14 @@
     end)
     swayimg.gallery.on_key("l", function()
       swayimg.gallery.switch_image("right")
+    end)
+    swayimg.gallery.on_key("S-Delete", function()
+      local image = swayimg.gallery.get_image()
+      if image then
+        os.remove(image.path)
+        swayimg.text.set_status("Deleted: " .. image.path)
+        swayimg.gallery.reload()
+      end
     end)
   '';
 }


### PR DESCRIPTION
Add `S-Delete` (Shift+Delete) key binding to delete the currently viewed/selected image from the filesystem.

**Viewer mode:** deletes the file and switches to the next image.
**Gallery mode:** deletes the file and reloads the gallery thumbnails.

Follows swayimg's modifier convention documented in [CONFIG.md](https://github.com/artemsen/swayimg/blob/master/CONFIG.md) — `S-Delete` for Shift+Delete (same pattern as `Ctrl-a`).