### PR TITLE
feat: add thunderbird email client module

### DIFF
--- a/apps/thunderbird/thunderbird.nix
+++ b/apps/thunderbird/thunderbird.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.thunderbird ];
+
+  # Enable native Wayland support under niri/sway
+  home.sessionVariables = {
+    MOZ_ENABLE_WAYLAND = "1";
+  };
+}

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -166,6 +166,9 @@ let
     firefox = {
       home = [ ../apps/firefox/firefox.nix ];
     };
+    thunderbird = {
+      home = [ ../apps/thunderbird/thunderbird.nix ];
+    };
     chromium = {
       home = [ ../apps/ungoogled-chromium/ungoogled-chromium.nix ];
     };
@@ -392,6 +395,7 @@ in
       "chromium"
       # "qutebrowser"
       # "mpd"
+      "thunderbird"
       "python"
       "code-agents"
       # "mullvad"


### PR DESCRIPTION
## Objectif

Ajout d'un module Thunderbird pour remplacer le webmail Mailo, qui est lent et désagréable sur desktop. Thunderbird desktop est le pendant naturel de Thunderbird Mobile utilisé sur Android.

## Changements

- **apps/thunderbird/thunderbird.nix** — Nouveau module home-manager :
  - Installation de Thunderbird (`pkgs.thunderbird`)
  - Activation du support Wayland natif (`MOZ_ENABLE_WAYLAND=1`) pour niri/sway
- **hosts/default.nix** — Nouveau profil `thunderbird` dans `moduleProfiles`
- **p14sg6** — Profil `thunderbird` activé

## Comptes à configurer

Une fois déployé, Thunderbird sera disponible. Les comptes à ajouter manuellement (IMAP/SMTP) :

| Provider | IMAP | SMTP |
|---|---|---|
| **Mailo** | imap.mailo.com:993 (SSL) | smtp.mailo.com:465 (SSL) |
| **Gmail** | imap.gmail.com:993 (SSL) | smtp.gmail.com:465 (SSL) |
| **Outlook** | outlook.office365.com:993 (SSL) | smtp.office365.com:587 (STARTTLS) |

## Vérification

- [x] `pre-commit-check` passe
- [x] Module créé et profil enregistré
- [x] Activé sur p14sg6 uniquement
