### PR TITLE
kimsufi: relais Tor non-exit (hôte nixos-kimsufi-tor)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -23,3 +23,7 @@ creation_rules:
     age: >-
       age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
       age19a42zcg3w93rpge59nrg8u9kdd0cnvrsl3v5fklnt2x229ax6ajqmphwre
+  - path_regex: 'secrets/tor\.yaml$'
+    age: >-
+      age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
+      age13txxxvheh5dp0lkt9h3mwlmr0k3j5a89wfllm2nuqtu78extpuasgz49zg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ mkHost = {
 
 **Servers (Kimsufi Proxmox VMs):**
 - `nixos-kimsufi-qbittorrent` - qbittorrent server
+- `nixos-kimsufi-tor` - Relais Tor non-exit
 
 **Servers (ERA VPS):**
 - `nixos-era-adguard` - AdGuard Home DNS server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ mkHost = {
 
 **Servers (Kimsufi Proxmox VMs):**
 - `nixos-kimsufi-qbittorrent` - qbittorrent server
-- `nixos-kimsufi-tor` - Relais Tor non-exit
+- `nixos-kimsufi-tor` - non-exit Tor relay
 
 **Servers (ERA VPS):**
 - `nixos-era-adguard` - AdGuard Home DNS server

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 
 ### Proxmox Kimsufi VMs (Dedicated Server)
 - **nixos-kimsufi-qbittorrent**: qbittorrent
+- **nixos-kimsufi-tor**: non-exit Tor relay
 
 ### Proxmox Era VMs (Home Server)
 - **nixos-era-hermes**: hermes with hermes-webui

--- a/apps/tor-relay/default.nix
+++ b/apps/tor-relay/default.nix
@@ -5,6 +5,14 @@
 #   - RAM:  1 Go (le relais consomme ~200-400 Mo)
 #   - Disque: 20 Go (les données du relais prennent ~1-2 Go)
 # La ressource clé est la bande passante (débit illimité du Kimsufi).
+#
+# L'identité du relais (Nickname/ContactInfo) est stockée chiffrée dans
+# secrets/tor.yaml (sops) et injectée dans torrc via `%include` :
+# le module tor de nixpkgs ne supporte pas le motif `_secret` dans settings.
+{
+  config,
+  ...
+}:
 {
   services.tor = {
     enable = true;
@@ -17,13 +25,31 @@
       role = "relay";
     };
     settings = {
-      # TODO: personnaliser (le Nickname doit être < 19 caractères).
-      Nickname = "dbeleyKimsufiRelay";
-      ContactInfo = "https://github.com/dbeley";
+      # Fragment torrc déchiffré par sops-nix au boot (Nickname + ContactInfo).
+      "%include" = config.sops.secrets."tor-identity".path;
       ORPort = [ 443 ];
       # Limites de bande passante: 4 Mo/s en moyenne, 6 Mo/s en rafale.
       BandwidthRate = "4 MB";
       BandwidthBurst = "6 MB";
     };
+  };
+
+  # Identité du relais (Nickname < 19 caractères, ContactInfo publique) hors
+  # du repo public. La clé age privée de l'hôte doit être installée sur la VM
+  # (~/.config/sops/age/keys.txt) avant le premier boot.
+  sops.secrets."tor-identity" = {
+    sopsFile = ../../secrets/tor.yaml;
+    owner = "tor";
+    group = "tor";
+    mode = "0440";
+  };
+
+  systemd.services.tor = {
+    # Attendre le déchiffrement sops au boot.
+    after = [ "sops-nix.service" ];
+    wants = [ "sops-nix.service" ];
+    # Le service tor tourne chrooté (RootDirectory=/run/tor/root) : le secret
+    # doit être monté dans le namespace du service pour être visible de torrc.
+    serviceConfig.BindReadOnlyPaths = [ config.sops.secrets."tor-identity".path ];
   };
 }

--- a/apps/tor-relay/default.nix
+++ b/apps/tor-relay/default.nix
@@ -1,0 +1,29 @@
+# Relais Tor non-exit.
+#
+# Ressources VM recommandées:
+#   - vCPU: 1
+#   - RAM:  1 Go (le relais consomme ~200-400 Mo)
+#   - Disque: 20 Go (les données du relais prennent ~1-2 Go)
+# La ressource clé est la bande passante (débit illimité du Kimsufi).
+{
+  services.tor = {
+    enable = true;
+    # Ouvre automatiquement le(s) port(s) du relais dans le firewall.
+    openFirewall = true;
+    relay = {
+      enable = true;
+      # "relay" = relais non-exit: on relaie le trafic onion entre nœuds Tor,
+      # jamais vers l'Internet public (le module force ExitPolicy "reject *:*").
+      role = "relay";
+    };
+    settings = {
+      # TODO: personnaliser (le Nickname doit être < 19 caractères).
+      Nickname = "dbeleyKimsufiRelay";
+      ContactInfo = "https://github.com/dbeley";
+      ORPort = [ 443 ];
+      # Limites de bande passante: 4 Mo/s en moyenne, 6 Mo/s en rafale.
+      BandwidthRate = "4 MB";
+      BandwidthBurst = "6 MB";
+    };
+  };
+}

--- a/apps/tor-relay/default.nix
+++ b/apps/tor-relay/default.nix
@@ -1,14 +1,3 @@
-# Relais Tor non-exit.
-#
-# Ressources VM recommandées:
-#   - vCPU: 1
-#   - RAM:  1 Go (le relais consomme ~200-400 Mo)
-#   - Disque: 20 Go (les données du relais prennent ~1-2 Go)
-# La ressource clé est la bande passante (débit illimité du Kimsufi).
-#
-# L'identité du relais (Nickname/ContactInfo) est stockée chiffrée dans
-# secrets/tor.yaml (sops) et injectée dans torrc via `%include` :
-# le module tor de nixpkgs ne supporte pas le motif `_secret` dans settings.
 {
   config,
   ...
@@ -16,27 +5,19 @@
 {
   services.tor = {
     enable = true;
-    # Ouvre automatiquement le(s) port(s) du relais dans le firewall.
     openFirewall = true;
     relay = {
       enable = true;
-      # "relay" = relais non-exit: on relaie le trafic onion entre nœuds Tor,
-      # jamais vers l'Internet public (le module force ExitPolicy "reject *:*").
       role = "relay";
     };
     settings = {
-      # Fragment torrc déchiffré par sops-nix au boot (Nickname + ContactInfo).
       "%include" = config.sops.secrets."tor-identity".path;
       ORPort = [ 443 ];
-      # Limites de bande passante: 4 Mo/s en moyenne, 6 Mo/s en rafale.
       BandwidthRate = "4 MB";
       BandwidthBurst = "6 MB";
     };
   };
 
-  # Identité du relais (Nickname < 19 caractères, ContactInfo publique) hors
-  # du repo public. La clé age privée de l'hôte doit être installée sur la VM
-  # (~/.config/sops/age/keys.txt) avant le premier boot.
   sops.secrets."tor-identity" = {
     sopsFile = ../../secrets/tor.yaml;
     owner = "tor";
@@ -45,11 +26,8 @@
   };
 
   systemd.services.tor = {
-    # Attendre le déchiffrement sops au boot.
     after = [ "sops-nix.service" ];
     wants = [ "sops-nix.service" ];
-    # Le service tor tourne chrooté (RootDirectory=/run/tor/root) : le secret
-    # doit être monté dans le namespace du service pour être visible de torrc.
     serviceConfig.BindReadOnlyPaths = [ config.sops.secrets."tor-identity".path ];
   };
 }

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -255,6 +255,11 @@ let
         ../apps/qbittorrent/default.nix
       ];
     };
+    tor-relay = {
+      system = [
+        ../apps/tor-relay/default.nix
+      ];
+    };
     jj = {
       home = [
         ../apps/jj/jj.nix
@@ -535,6 +540,15 @@ in
       "bootloader-grub-bios"
       "openssh-server"
       "qbittorrent"
+    ];
+  };
+  nixos-kimsufi-tor = mkHost {
+    hostName = "nixos-kimsufi-tor";
+    stateVersion = "26.11";
+    profiles = [
+      "bootloader-grub-bios"
+      "openssh-server"
+      "tor-relay"
     ];
   };
   nixos-era-hermes = mkHost {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -548,6 +548,7 @@ in
     profiles = [
       "bootloader-grub-bios"
       "openssh-server"
+      "sops"
       "tor-relay"
     ];
   };

--- a/hosts/nixos-kimsufi-tor/hardware-configuration.nix
+++ b/hosts/nixos-kimsufi-tor/hardware-configuration.nix
@@ -25,25 +25,14 @@
     extraModulePackages = [ ];
   };
 
-  # Partitions créées par scripts/install-nixos.sh (labels boot/nixos/swap)
   fileSystems = {
     "/" = {
-      device = "/dev/disk/by-label/nixos";
-      fsType = "ext4";
-    };
-    "/boot" = {
-      device = "/dev/disk/by-label/boot";
+      device = "/dev/disk/by-uuid/ee34661b-f018-48d0-9947-1aa816ad149e";
       fsType = "ext4";
     };
   };
 
-  swapDevices = [
-    {
-      device = "/dev/disk/by-label/swap";
-    }
-  ];
-
   networking.useDHCP = lib.mkDefault true;
-
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  services.qemuGuest.enable = true;
 }

--- a/hosts/nixos-kimsufi-tor/hardware-configuration.nix
+++ b/hosts/nixos-kimsufi-tor/hardware-configuration.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot = {
+    initrd = {
+      availableKernelModules = [
+        "ata_piix"
+        "uhci_hcd"
+        "virtio_pci"
+        "virtio_scsi"
+        "sd_mod"
+        "sr_mod"
+      ];
+      kernelModules = [ ];
+    };
+    kernelModules = [ ];
+    extraModulePackages = [ ];
+  };
+
+  # Partitions créées par scripts/install-nixos.sh (labels boot/nixos/swap)
+  fileSystems = {
+    "/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+    };
+    "/boot" = {
+      device = "/dev/disk/by-label/boot";
+      fsType = "ext4";
+    };
+  };
+
+  swapDevices = [
+    {
+      device = "/dev/disk/by-label/swap";
+    }
+  ];
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/nixos-kimsufi-tor/home.nix
+++ b/hosts/nixos-kimsufi-tor/home.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ ];
+}

--- a/secrets/tor.yaml
+++ b/secrets/tor.yaml
@@ -1,0 +1,25 @@
+tor-identity: ENC[AES256_GCM,data:Xt+iLtvLg8mVQfQ2GWGUsxTcZgztlpzVuD8A2Y1PumV4RDZRMMnrfEVjLQ/NPhfW8L2vy30lmM3uvG5Z1bLUiDyC,iv:KFVil23dsNsXhpj9KqumHvJJ1Y4liOdQ81msGRPgdmY=,tag:EcJgbQ7N7T7HPKLxaDyKAw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTNzUzOUt0cGRTZDZYWGd0
+            TXZtS3lieEJWZGNNWklCZmZIZUxDaFl5NENvCjJsdTRYYWZrQ3JLRUFMQWZuNGY2
+            NE1LYUVzSldoUXRWZXFyWENHa2N4TGsKLS0tIEw0NEI3Y2hRSUsvL2NVOE5KUUZV
+            V0ZkTVl6dHZZMDYxc0pNWTlpTVhlakUKUjm3QIbXOrUmA3uu3JRPr+ykw7uJmcUa
+            BDSJxCNLFwJ5GlWgWOOJovajQYNIm6w7DLnj7mRYtSXu0M45RkA9SQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMTjBVaXFhUkgrdWd2M3Fk
+            aDRoZm93RVh0TzJ5YmI2Sjl1YWR0KzVuNGs0ClBybWtjbDRWV2phb2pPTXB4Vy9r
+            aUhld21tRXpRSWxlayt5cUd6ZGovTVEKLS0tIGxyekp2M3AxQ3FpMEU4T294ZmE4
+            SjNlWjB0YnBuZGQvSzJ1bEhMZHkwaFEKRpubxDYY3kpSRHjcqY613/Keo+oOrp3k
+            uV1Sp0SN7b9z0lgy70/Tmen+TtNYmsCRyO7mr1fiWIoNiyCs6e08yA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13txxxvheh5dp0lkt9h3mwlmr0k3j5a89wfllm2nuqtu78extpuasgz49zg
+    lastmodified: "2026-08-04T02:09:17Z"
+    mac: ENC[AES256_GCM,data:rFNHgH/kHJlA1dXk3YcRNDX31WPNYr/fyKRr5VeVboHt7BacEGIReezh+Io5MI+sR0DoLwBxOxB4FSioXHAHM++rZgmOMVKwAfFe3uubGHBeGP1TJ0E4W/g0gg6t5JzqcbPO7wKRW3LPvotxF4U7NCw1tUAXXWsMdo43ZidufyM=,iv:iqBp7Qve9bgwm987Fhb/xIIPPkV51dsaNdUmoBBInrU=,tag:Lhjl1wILXhJ54fEq/4LQqw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/secrets/tor.yaml
+++ b/secrets/tor.yaml
@@ -1,4 +1,4 @@
-tor-identity: ENC[AES256_GCM,data:Xt+iLtvLg8mVQfQ2GWGUsxTcZgztlpzVuD8A2Y1PumV4RDZRMMnrfEVjLQ/NPhfW8L2vy30lmM3uvG5Z1bLUiDyC,iv:KFVil23dsNsXhpj9KqumHvJJ1Y4liOdQ81msGRPgdmY=,tag:EcJgbQ7N7T7HPKLxaDyKAw==,type:str]
+tor-identity: ENC[AES256_GCM,data:SW5FnE6kvGWwBH8ObZZQzETrxWSaK2TbCZJ1M6ey3L6T77y5tsZs5qz+vpAqqWa4PXQVJMzEgh08eW75QSkp,iv:tueyGchRYMMYf0CF7ofsh87sxwZKNtXVNpzdZAKm1xI=,tag:yweI+5rtNH4XSoSW6J3s1Q==,type:str]
 sops:
     age:
         - enc: |
@@ -19,7 +19,7 @@ sops:
             uV1Sp0SN7b9z0lgy70/Tmen+TtNYmsCRyO7mr1fiWIoNiyCs6e08yA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13txxxvheh5dp0lkt9h3mwlmr0k3j5a89wfllm2nuqtu78extpuasgz49zg
-    lastmodified: "2026-08-04T02:09:17Z"
-    mac: ENC[AES256_GCM,data:rFNHgH/kHJlA1dXk3YcRNDX31WPNYr/fyKRr5VeVboHt7BacEGIReezh+Io5MI+sR0DoLwBxOxB4FSioXHAHM++rZgmOMVKwAfFe3uubGHBeGP1TJ0E4W/g0gg6t5JzqcbPO7wKRW3LPvotxF4U7NCw1tUAXXWsMdo43ZidufyM=,iv:iqBp7Qve9bgwm987Fhb/xIIPPkV51dsaNdUmoBBInrU=,tag:Lhjl1wILXhJ54fEq/4LQqw==,type:str]
+    lastmodified: "2026-08-04T07:51:40Z"
+    mac: ENC[AES256_GCM,data:k+IPhAllhnIq97zmmRafUXwXDQkFif+nbXHYA9h8lAiFGQeCpKnNG5oBYaW7217apKkbYqK/p53dGu0pcAI74PaCu/8GdjiP7J7QQHeQMOFs38gRrW2UFJEJAHE1bDzV6zsreBlHKtNevjDhK5Kxp7o3RUx5AWBbbSKBayfOzWw=,iv:JXfyjOqW6OCm04JsPcqEKOhzKUM2OsVVJLEZ25VSH8Q=,tag:KAGN9SSc4XgZqvuw4+TtQQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Résumé

Ajoute un hôte Kimsufi dédié `nixos-kimsufi-tor` qui héberge un **relais Tor non-exit** (`services.tor`, rôle `relay` → `ExitPolicy reject *:*` forcé par le module nixpkgs). L'identité du relais (`Nickname`/`ContactInfo`) est gérée par **sops** : hors du repo public, déchiffrée au boot sur la VM.

## Contenu

- `apps/tor-relay/default.nix` — nouveau module app : relais Tor non-exit
  - `ORPort = 443`, limites de bande passante 4 Mo/s (rafale 6 Mo/s)
  - `openFirewall = true` (le module gère le setcap pour le port < 1024)
  - **Identité sops** : `Nickname`/`ContactInfo` stockés dans `secrets/tor.yaml` sous forme de fragment torrc, inclus via `%include` (le module tor de nixpkgs n'expose pas le motif `_secret` pour `settings`). Le secret est monté en lecture seule dans le chroot de `tor.service` (`BindReadOnlyPaths`, le service tourne chrooté dans `/run/tor/root`) et le service attend `sops-nix.service` au boot.
- `secrets/tor.yaml` — fragment chiffré (clé principale dbeley + clé age de l'hôte, cf. `.sops.yaml`)
- `.sops.yaml` — règle de création `secrets/tor.yaml`
- `hosts/nixos-kimsufi-tor/` — `hardware-configuration.nix` + `home.nix`
- `hosts/default.nix` — hôte avec profils : `bootloader-grub-bios`, `openssh-server`, `sops`, `tor-relay`
- `AGENTS.md` — hôte ajouté à la liste

## Ressources VM recommandées (Proxmox)

| Ressource | Suggestion | Notes |
|---|---|---|
| vCPU | **1** | le relais est peu gourmand en CPU |
| RAM | **1 Go** | ~200-400 Mo utilisés par tor, zram présent côté config |
| Disque | **20 Go** | données du relais ~1-2 Go, marge pour le système |
| Bande passante | illimité Kimsufi | **la ressource clé** — le relais fait ~4 Mo/s constant |

## Notes

- **Différence avec l'host qbittorrent existant** : le hardware-config utilise les labels de partition (`/dev/disk/by-label/nixos|boot|swap`) créés par `scripts/install-nixos.sh`, au lieu d'un UUID figé → fonctionne sans modification après l'install script.
- **Vérifications effectuées** : `nix eval` de la config complète de l'hôte OK (settings tor + chemin sops `/run/secrets/tor-identity`), déchiffrement sops testé avec la clé privée de l'hôte, `pre-commit-check` OK (nixfmt, statix, deadnix, shellcheck…).

## ⚠️ Clé age de l'hôte (bootstrap sops)

La paire de clés age de l'hôte a été générée (publique dans `.sops.yaml`, secret déjà chiffré). **La clé privée est sur la machine locale** (hors repo) :

```
~/.config/sops/age/kimsufi-keys/nixos-kimsufi-tor.agekey
```

À installer sur la VM après création (avant le premier `boot-proxmox-vm`) :

```bash
scp ~/.config/sops/age/kimsufi-keys/nixos-kimsufi-tor.agekey david@<IP>:/tmp/
ssh david@<IP> "install -d -m 700 ~/.config/sops/age && mv /tmp/nixos-kimsufi-tor.agekey ~/.config/sops/age/keys.txt && chmod 600 ~/.config/sops/age/keys.txt"
```

*Si tu préfères générer la clé toi-même sur la VM* (`just secrets-gen-key`), remplace la clé publique dans `.sops.yaml` et ré-encrypte avec `just secrets-edit secrets/tor.yaml`.

## Déploiement

```bash
# 1. Créer la VM sur Proxmox (1 vCPU / 1 Go / 20 Go), puis:
just install-proxmox-vm nixos-kimsufi-tor <IP>
# 2. Installer la clé age (voir section ci-dessus)
# 3. Après reboot:
just boot-proxmox-vm nixos-kimsufi-tor <IP>
# 4. Vérifier:
ssh david@<IP> "systemctl status tor"
# 5. (Optionnel) suivre l'apparition du relais:
#    https://metrics.torproject.org/rs.html#search/dbeleyKimsufiRelay
```

Le relais apparaîtra dans le consensus Tor après quelques heures.
