### PR TITLE
kimsufi: instance PeerTube publique (hôte nixos-kimsufi-peertube)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -27,7 +27,3 @@ creation_rules:
     age: >-
       age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
       age1f4uc39uuyllsxqpuyw8dk7lq5mw88jy7sg9hng4zhnctdcsgg3fsm7htxh
-  - path_regex: 'secrets/attic\.yaml$'
-    age: >-
-      age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
-      age1qdt7c094sq6pt3sh7d3dx2ugj4txdkycs48ha0r33f2787vkxyqsm7xfu3

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -23,3 +23,11 @@ creation_rules:
     age: >-
       age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
       age19a42zcg3w93rpge59nrg8u9kdd0cnvrsl3v5fklnt2x229ax6ajqmphwre
+  - path_regex: 'secrets/peertube\.yaml$'
+    age: >-
+      age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
+      age1f4uc39uuyllsxqpuyw8dk7lq5mw88jy7sg9hng4zhnctdcsgg3fsm7htxh
+  - path_regex: 'secrets/attic\.yaml$'
+    age: >-
+      age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
+      age1qdt7c094sq6pt3sh7d3dx2ugj4txdkycs48ha0r33f2787vkxyqsm7xfu3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ mkHost = {
 
 **Servers (Kimsufi Proxmox VMs):**
 - `nixos-kimsufi-qbittorrent` - qbittorrent server
+- `nixos-kimsufi-peertube` - Instance PeerTube publique
 
 **Servers (ERA VPS):**
 - `nixos-era-adguard` - AdGuard Home DNS server

--- a/apps/peertube/default.nix
+++ b/apps/peertube/default.nix
@@ -1,0 +1,82 @@
+# Instance PeerTube publique.
+#
+# Ressources VM recommandées (Proxmox):
+#   - vCPU:  2 (4 si transcodage vidéo intensif — ffmpeg logiciel)
+#   - RAM:   4 Go minimum, 8 Go confortable (postgres + redis + node)
+#   - Disque: 100-200 Go (vidéos + transcodages temporaires)
+#   - Domaine public requis: DNS A → IP de la VM (TLS Let's Encrypt)
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # TODO: remplacer par le vrai domaine public de l'instance (DNS A → IP de la VM).
+  peertubeDomain = "peertube.example.com";
+  # TODO: email admin (utilisé par Let's Encrypt et affiché par PeerTube).
+  adminEmail = "admin@example.com";
+in
+{
+  services.peertube = {
+    enable = true;
+    localDomain = peertubeDomain;
+    # Le module génère le reverse proxy nginx complet.
+    configureNginx = true;
+    # Accès public en HTTPS (port 443).
+    enableWebHttps = true;
+    listenWeb = 443;
+    # Secrets générés au premier boot (hors du store Nix).
+    secrets.secretsFile = "/var/lib/peertube/secret";
+    serviceEnvironmentFile = "/var/lib/peertube/admin-env";
+    # Postgres et Redis locaux (gérés par le module).
+    database.createLocally = true;
+    redis.createLocally = true;
+    settings = {
+      # Instance publique mais sans inscription ouverte (comptes créés par l'admin).
+      signup.enabled = false;
+      administration.email = adminEmail;
+    };
+  };
+
+  # Génère les secrets au premier démarrage (persistants entre les reboots).
+  systemd.services.peertube-secrets = {
+    description = "Generate PeerTube secrets on first boot";
+    before = [ "peertube.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = with pkgs; [ coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      install -d -o peertube -g peertube -m 0750 /var/lib/peertube
+      if [ ! -s /var/lib/peertube/secret ]; then
+        ${pkgs.openssl}/bin/openssl rand -hex 32 > /var/lib/peertube/secret
+        chown peertube:peertube /var/lib/peertube/secret
+        chmod 0600 /var/lib/peertube/secret
+      fi
+      if [ ! -s /var/lib/peertube/admin-env ]; then
+        printf 'PT_INITIAL_ROOT_PASSWORD=%s\n' "$(${pkgs.openssl}/bin/openssl rand -base64 24)" > /var/lib/peertube/admin-env
+        chown peertube:peertube /var/lib/peertube/admin-env
+        chmod 0600 /var/lib/peertube/admin-env
+      fi
+    '';
+  };
+
+  # TLS Let's Encrypt pour le domaine de l'instance.
+  services.nginx.virtualHosts.${peertubeDomain} = {
+    enableACME = true;
+    forceSSL = true;
+  };
+
+  security.acme = {
+    acceptTerms = true;
+    defaults.email = adminEmail;
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/apps/peertube/default.nix
+++ b/apps/peertube/default.nix
@@ -6,7 +6,8 @@
 #   - Disque: 100-200 Go (vidéos + transcodages temporaires)
 #   - Domaine public requis: DNS A → IP de la VM (TLS Let's Encrypt)
 {
-  pkgs,
+  config,
+  lib,
   ...
 }:
 let
@@ -24,9 +25,9 @@ in
     # Accès public en HTTPS (port 443).
     enableWebHttps = true;
     listenWeb = 443;
-    # Secrets générés au premier boot (hors du store Nix).
-    secrets.secretsFile = "/var/lib/peertube/secret";
-    serviceEnvironmentFile = "/var/lib/peertube/admin-env";
+    # Secrets sops (déchiffrés au boot par sops-nix, fichier secrets/peertube.yaml).
+    secrets.secretsFile = config.sops.secrets."peertube-secret".path;
+    serviceEnvironmentFile = config.sops.secrets."peertube-admin-password".path;
     # Postgres et Redis locaux (gérés par le module).
     database.createLocally = true;
     redis.createLocally = true;
@@ -37,29 +38,27 @@ in
     };
   };
 
-  # Génère les secrets au premier démarrage (persistants entre les reboots).
-  systemd.services.peertube-secrets = {
-    description = "Generate PeerTube secrets on first boot";
-    before = [ "peertube.service" ];
-    wantedBy = [ "multi-user.target" ];
-    path = with pkgs; [ coreutils ];
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
+  sops.secrets = {
+    "peertube-secret" = {
+      sopsFile = ../../secrets/peertube.yaml;
+      # Le service tourne en peertube:peertube et lit le secret au démarrage.
+      owner = "peertube";
+      group = "peertube";
+      mode = "0440";
     };
-    script = ''
-      install -d -o peertube -g peertube -m 0750 /var/lib/peertube
-      if [ ! -s /var/lib/peertube/secret ]; then
-        ${pkgs.openssl}/bin/openssl rand -hex 32 > /var/lib/peertube/secret
-        chown peertube:peertube /var/lib/peertube/secret
-        chmod 0600 /var/lib/peertube/secret
-      fi
-      if [ ! -s /var/lib/peertube/admin-env ]; then
-        printf 'PT_INITIAL_ROOT_PASSWORD=%s\n' "$(${pkgs.openssl}/bin/openssl rand -base64 24)" > /var/lib/peertube/admin-env
-        chown peertube:peertube /var/lib/peertube/admin-env
-        chmod 0600 /var/lib/peertube/admin-env
-      fi
-    '';
+    "peertube-admin-password" = {
+      sopsFile = ../../secrets/peertube.yaml;
+      owner = "peertube";
+      group = "peertube";
+      mode = "0440";
+    };
+  };
+
+  # Attendre le déchiffrement sops au boot.
+  systemd.services.peertube = {
+    after = [ "sops-nix.service" ];
+    wants = [ "sops-nix.service" ];
+    serviceConfig.BindReadOnlyPaths = lib.mkAfter [ "/run/secrets" ];
   };
 
   # TLS Let's Encrypt pour le domaine de l'instance.

--- a/apps/peertube/default.nix
+++ b/apps/peertube/default.nix
@@ -6,8 +6,6 @@
 #   - Disque: 100-200 Go (vidéos + transcodages temporaires)
 #   - Domaine public requis: DNS A → IP de la VM (TLS Let's Encrypt)
 {
-  config,
-  lib,
   pkgs,
   ...
 }:

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -255,6 +255,11 @@ let
         ../apps/qbittorrent/default.nix
       ];
     };
+    peertube = {
+      system = [
+        ../apps/peertube/default.nix
+      ];
+    };
     jj = {
       home = [
         ../apps/jj/jj.nix
@@ -535,6 +540,15 @@ in
       "bootloader-grub-bios"
       "openssh-server"
       "qbittorrent"
+    ];
+  };
+  nixos-kimsufi-peertube = mkHost {
+    hostName = "nixos-kimsufi-peertube";
+    stateVersion = "26.11";
+    profiles = [
+      "bootloader-grub-bios"
+      "openssh-server"
+      "peertube"
     ];
   };
   nixos-era-hermes = mkHost {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -548,6 +548,7 @@ in
     profiles = [
       "bootloader-grub-bios"
       "openssh-server"
+      "sops"
       "peertube"
     ];
   };

--- a/hosts/nixos-kimsufi-peertube/hardware-configuration.nix
+++ b/hosts/nixos-kimsufi-peertube/hardware-configuration.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot = {
+    initrd = {
+      availableKernelModules = [
+        "ata_piix"
+        "uhci_hcd"
+        "virtio_pci"
+        "virtio_scsi"
+        "sd_mod"
+        "sr_mod"
+      ];
+      kernelModules = [ ];
+    };
+    kernelModules = [ ];
+    extraModulePackages = [ ];
+  };
+
+  # Partitions créées par scripts/install-nixos.sh (labels boot/nixos/swap)
+  fileSystems = {
+    "/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+    };
+    "/boot" = {
+      device = "/dev/disk/by-label/boot";
+      fsType = "ext4";
+    };
+  };
+
+  swapDevices = [
+    {
+      device = "/dev/disk/by-label/swap";
+    }
+  ];
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/nixos-kimsufi-peertube/home.nix
+++ b/hosts/nixos-kimsufi-peertube/home.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ ];
+}

--- a/secrets/peertube.yaml
+++ b/secrets/peertube.yaml
@@ -1,0 +1,26 @@
+peertube-secret: ENC[AES256_GCM,data:x0B+055Hm0EahfjSrmlXhDZe5tKbjUwcjNPwrpJ/SvNpRfenxUi/Sgq6vjLXv5kYPCggxExM62jySf8fmhrlew==,iv:SEugVeUSOtRy2rpnXO8uQl6s1rHF30PoIDsHsIFiHlU=,tag:9er9HXKXKPmgLQe76J1Qzg==,type:str]
+peertube-admin-password: ENC[AES256_GCM,data:8cjbuzRhiYtOQKyyJQRJnGfYY+lVQlBYQ+Buw/Lmjn1yW0kbGZ/+71uTBCqX3ucQPWu7CFlw02bV3g==,iv:h0vofOusrDt/KlO7w0L0TDP638D02G1ZIBZhrP5KUwI=,tag:JjeBFfbV6bkwO8yRoJmC7A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaem9nd3JtditDVHJFOUJE
+            Wlh5eVVrQ3lDd3lTZmRhT0J2a2lTa3ZYZkdVCkxRUmhMak9CUmMxQU80YzJRd0dw
+            emx2Tzl1djVJRHQ1Q0YrSUVtOTRCWTAKLS0tIHQwTVA2b2plbWJFaSt3Nm4xeThm
+            bzdNNnFyVnQ5VGx3bDNHZU9weGxrcm8KXLalRWsWgADbOMiWSduYsz0clTBJ5sQs
+            I33D1FRI4C8p7995Bi379q/eYStVlzvzXn1lS3K2HZA/ypsHFBwzKQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFb3BnSzF5dUpqMlNqQmJ2
+            Y0hlWlc5RXJwVVMySUg0QUh4MUZzeDQ2MmtZCkVqazE5YmZnZjlsTXAzRTdRalJJ
+            S0ZGd21kSGNlYTZuSjh1VFlnY2hjU1EKLS0tIHZ6VG5TYkg5QVhReXplRmVCWHpE
+            R1hKZHNWczZPbkhOcHd5YzZ1V292ZDQKLOXfsGY9DKL/Vjmh5tOR3VIIAcxxVUpA
+            lnNG3omUn2+H2A+4K8vlOLanWYcZzucfj8xQSjnSsAftuFVW0KXsiA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f4uc39uuyllsxqpuyw8dk7lq5mw88jy7sg9hng4zhnctdcsgg3fsm7htxh
+    lastmodified: "2026-08-03T15:47:03Z"
+    mac: ENC[AES256_GCM,data:Y+vGD6kzBzBP+xyzE6m6eHaWfXpUsJ9iaUC0p7xvD3nj70WXylIEmYGB8wBVaGREcEAiwNaBkgG80OisQKcFQiuEH6ALcbXD1dYjF/nzXx9l2WutUKw5XvfHJHQF2k887wzooeLdDXltt3pnL9AZD2zWfbD26sOm677TFM8Otyw=,iv:HX8CZJ+DxQRtJlt+KabLx2qVuolmGTp/yc9BeGMREKk=,tag:GmPxImHsEbI7RVGTVBNK/Q==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## Résumé

Ajoute un hôte Kimsufi dédié `nixos-kimsufi-peertube` qui héberge une **instance PeerTube publique** (module nixpkgs `services.peertube`), avec les secrets gérés par **sops** (convention du repo : secrets séparés par use-case).

## Contenu

- `apps/peertube/default.nix` — nouveau module app :
  - `configureNginx = true` : reverse proxy nginx généré par le module
  - HTTPS : `enableWebHttps = true`, `listenWeb = 443`, TLS Let's Encrypt (ACME) sur le vhost
  - Postgres + Redis locaux gérés par le module (`createLocally = true`)
  - Inscriptions fermées (`signup.enabled = false`)
  - **Secrets sops** (`secrets/peertube.yaml`, chiffré sops) :
    - `peertube-secret` → `services.peertube.secrets.secretsFile`
    - `peertube-admin-password` (`PT_INITIAL_ROOT_PASSWORD=…`) → `serviceEnvironmentFile`
    - Accès service : `owner/group = peertube`, `mode = 0440`, attente de `sops-nix.service`
  - ⚠️ **TODO dans le fichier** : `peertubeDomain = "peertube.example.com"` et `adminEmail` à remplacer (DNS A → IP de la VM requis avant le déploiement)
- `secrets/peertube.yaml` — secrets chiffrés (clés : clé principale dbeley + clé age de l'hôte, cf. `.sops.yaml`)
- `.sops.yaml` — règle de création `secrets/peertube.yaml` (clé principale + clé hôte)
- `hosts/nixos-kimsufi-peertube/` — hardware-config (labels de partitions) + home.nix
- `hosts/default.nix` — profil `peertube` + hôte (`bootloader-grub-bios`, `openssh-server`, `sops`, `peertube`)
- `AGENTS.md` — hôte ajouté à la liste

## Ressources VM recommandées (Proxmox)

| Ressource | Suggestion | Notes |
|---|---|---|
| vCPU | **2** (4 si transcodage intensif) | transcodage ffmpeg logiciel (pas de GPU dans la VM) |
| RAM | **4 Go min, 8 Go confortable** | postgres + redis + node ; zram présent côté config |
| Disque | **100-200 Go** | vidéos + transcodages temporaires (`/var/lib/peertube/storage`) |
| Réseau | 1 IP publique + **domaine** | DNS A → IP de la VM pour le TLS |

## ⚠️ Clé age de l'hôte (bootstrap sops)

La paire de clés age de l'hôte a été générée (publique dans `.sops.yaml`, secrets déjà chiffrés). **La clé privée est sur la machine era-hermes** (pas dans le repo) :

```bash
~/.config/sops/age/kimsufi-keys/nixos-kimsufi-peertube.agekey
```

À installer sur la VM après création :
```bash
scp ~/.config/sops/age/kimsufi-keys/nixos-kimsufi-peertube.agekey david@<IP>:/tmp/
ssh david@<IP> "install -d -m 700 ~/.config/sops/age && mv /tmp/nixos-kimsufi-peertube.agekey ~/.config/sops/age/keys.txt && chmod 600 ~/.config/sops/age/keys.txt"
```

*Si tu préfères générer la clé toi-même sur la VM* (`just secrets-gen-key`), remplace la clé publique dans `.sops.yaml` et ré-encrypte avec `just secrets-edit secrets/peertube.yaml`.

## Vérifications effectuées

- Évaluation complète de l'hôte OK ; chemins sops `/run/secrets/peertube-secret` + `peertube-admin-password` (mode 0440, owner/group peertube), `sops-nix.service` bien dans l'ordre de démarrage du service
- Chiffrement sops vérifié : `secrets/peertube.yaml` déchiffrable avec la clé privée de l'hôte
- `pre-commit-check` OK (nixfmt, statix, deadnix, shellcheck)

## Déploiement

```bash
# 0. Remplacer peertubeDomain/adminEmail dans apps/peertube/default.nix
#    + créer l'enregistrement DNS (peertube.<domaine> → IP de la VM)
# 1. Créer la VM sur Proxmox (2 vCPU / 4 Go / 100 Go), puis:
just install-proxmox-vm nixos-kimsufi-peertube <IP>
# 2. Installer la clé age (voir section ci-dessus), puis:
just boot-proxmox-vm nixos-kimsufi-peertube <IP>
# 3. Vérifier le déchiffrement sops:
just secrets-test   # avec HOST=nixos-kimsufi-peertube (ou nixos-rebuild dry-activate --flake .#nixos-kimsufi-peertube)
# 4. https://peertube.<domaine> — se connecter en root
#    (mot de passe initial: PT_INITIAL_ROOT_PASSWORD dans secrets/peertube.yaml, à changer dans l'UI)
```
