### PR TITLE
apps: add komga, mylar, lazylibrarian (BD, livres, presse)

### DIFF
--- a/apps/komga/default.nix
+++ b/apps/komga/default.nix
@@ -1,0 +1,51 @@
+{
+  user,
+  lib,
+  ...
+}:
+let
+  komgaHost = "komga.home";
+  komgaPort = 25600;
+in
+{
+  services.komga = {
+    enable = true;
+    inherit user;
+    group = "media";
+    settings.server.port = komgaPort;
+  };
+
+  systemd.services.komga = {
+    requires = [ "mnt-nfs-WDC14_2.mount" ];
+    after = [
+      "mnt-nfs-WDC14_2.mount"
+      "network-online.target"
+    ];
+    serviceConfig = {
+      PrivateUsers = lib.mkForce false;
+      UMask = "0027";
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    virtualHosts.${komgaHost} = {
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString komgaPort}";
+        proxyWebsockets = true;
+        recommendedProxySettings = true;
+        extraConfig = ''
+          client_max_body_size 500m;
+          proxy_buffering off;
+          proxy_cache off;
+          chunked_transfer_encoding on;
+        '';
+      };
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/apps/lazylibrarian/default.nix
+++ b/apps/lazylibrarian/default.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  user,
+  ...
+}:
+let
+  lazylibrarianHost = "lazylibrarian.home";
+  lazylibrarianPort = 5299;
+  nfsMount = "/mnt/nfs/WDC14_2";
+  configDir = "/var/lib/lazylibrarian/config";
+  uid =
+    let
+      u = config.users.users.${user}.uid or null;
+    in
+    if u == null then "1000" else toString u;
+  mediaGid =
+    let
+      g = config.users.groups.media.gid or null;
+    in
+    if g == null then "169" else toString g;
+in
+{
+  virtualisation = {
+    podman.enable = true;
+    oci-containers.containers.lazylibrarian = {
+      image = "lscr.io/linuxserver/lazylibrarian:latest";
+      autoStart = true;
+      ports = [ "127.0.0.1:${toString lazylibrarianPort}:5299" ];
+      volumes = [
+        "${configDir}:/config"
+        "${nfsMount}/Downloads/lazylibrarian:/downloads"
+        "${nfsMount}/Books:/books"
+        "${nfsMount}/Magazines:/magazines"
+      ];
+      environment = {
+        TZ = "Europe/Paris";
+        PUID = toString uid;
+        PGID = toString mediaGid;
+      };
+      extraOptions = [ "--pull=newer" ];
+    };
+  };
+
+  systemd.services."podman-lazylibrarian" = {
+    requires = [ "mnt-nfs-WDC14_2.mount" ];
+    after = [
+      "mnt-nfs-WDC14_2.mount"
+      "network-online.target"
+    ];
+  };
+
+  systemd.tmpfiles.rules = [
+    "d ${configDir} 0775 root root -"
+  ];
+
+  services.nginx = {
+    enable = true;
+    virtualHosts.${lazylibrarianHost} = {
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString lazylibrarianPort}";
+        proxyWebsockets = true;
+        recommendedProxySettings = true;
+        extraConfig = "client_max_body_size 500m;";
+      };
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/apps/mylar/default.nix
+++ b/apps/mylar/default.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  user,
+  ...
+}:
+let
+  mylarHost = "mylar.home";
+  mylarPort = 8090;
+  nfsMount = "/mnt/nfs/WDC14_2";
+  configDir = "/var/lib/mylar/config";
+  uid =
+    let
+      u = config.users.users.${user}.uid or null;
+    in
+    if u == null then "1000" else toString u;
+  mediaGid =
+    let
+      g = config.users.groups.media.gid or null;
+    in
+    if g == null then "169" else toString g;
+in
+{
+  virtualisation = {
+    podman.enable = true;
+    oci-containers.containers.mylar = {
+      image = "lscr.io/linuxserver/mylar3:latest";
+      autoStart = true;
+      ports = [ "127.0.0.1:${toString mylarPort}:8090" ];
+      volumes = [
+        "${configDir}:/config"
+        "${nfsMount}/Downloads/mylar:/downloads"
+        "${nfsMount}/Comics:/comics"
+      ];
+      environment = {
+        TZ = "Europe/Paris";
+        PUID = toString uid;
+        PGID = toString mediaGid;
+      };
+      extraOptions = [ "--pull=newer" ];
+    };
+  };
+
+  systemd.services."podman-mylar" = {
+    requires = [ "mnt-nfs-WDC14_2.mount" ];
+    after = [
+      "mnt-nfs-WDC14_2.mount"
+      "network-online.target"
+    ];
+  };
+
+  systemd.tmpfiles.rules = [
+    "d ${configDir} 0775 root root -"
+  ];
+
+  services.nginx = {
+    enable = true;
+    virtualHosts.${mylarHost} = {
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString mylarPort}";
+        proxyWebsockets = true;
+        recommendedProxySettings = true;
+        extraConfig = "client_max_body_size 500m;";
+      };
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/apps/shelfmark/default.nix
+++ b/apps/shelfmark/default.nix
@@ -1,11 +1,37 @@
-{ domain, ... }:
+{
+  domain,
+  user,
+  lib,
+  ...
+}:
 let
   shelfmarkHost = "shelfmark.${domain}";
   shelfmarkPort = 8084;
+  nfsMount = "/mnt/nfs/WDC14_2";
 in
 {
   services.shelfmark = {
     enable = true;
+    environment = {
+      FLASK_HOST = "127.0.0.1";
+      FLASK_PORT = shelfmarkPort;
+      SEARCH_MODE = "universal";
+      BOOK_LANGUAGE = "fr,en";
+      INGEST_DIR = "${nfsMount}/Books";
+    };
+  };
+
+  systemd.services.shelfmark = {
+    requires = [ "mnt-nfs-WDC14_2.mount" ];
+    after = [
+      "mnt-nfs-WDC14_2.mount"
+      "network-online.target"
+    ];
+    serviceConfig = {
+      DynamicUser = lib.mkForce false;
+      User = user;
+      Group = "media";
+    };
   };
 
   services.nginx = {
@@ -14,7 +40,7 @@ in
       useACMEHost = domain;
       forceSSL = true;
       locations."/" = {
-        proxyPass = "http://localhost:${toString shelfmarkPort}";
+        proxyPass = "http://127.0.0.1:${toString shelfmarkPort}";
         proxyWebsockets = true;
         recommendedProxySettings = true;
         extraConfig = "client_max_body_size 500m;";

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -156,6 +156,21 @@ let
         ../apps/nixflix/default.nix
       ];
     };
+    komga = {
+      system = [
+        ../apps/komga/default.nix
+      ];
+    };
+    mylar = {
+      system = [
+        ../apps/mylar/default.nix
+      ];
+    };
+    lazylibrarian = {
+      system = [
+        ../apps/lazylibrarian/default.nix
+      ];
+    };
     podman = {
       system = [
         ../apps/podman/default.nix
@@ -568,6 +583,10 @@ in
       "sops"
       "acme"
       "nixflix"
+      "komga"
+      "mylar"
+      "lazylibrarian"
+      "shelfmark"
     ];
   };
   nixos-era-adguard = mkHost {


### PR DESCRIPTION
Nouveaux profils pour nixos-era-nixflix:
- komga: lecteur BD/magazines/ebooks, service natif nixpkgs (port 25600, vhost komga.home, PrivateUsers desactive pour l'acces NFS)
- mylar: telechargement auto de BD, conteneur podman linuxserver/mylar3 (vhost mylar.home, NFS WDC14_2: Comics + Downloads/mylar)
- lazylibrarian: livres + presse via recettes Calibre, conteneur podman linuxserver (vhost lazylibrarian.home, NFS: Books/Magazines/Downloads)

PUID/PGID repli sur 1000/169 (ids assignes a l'activation par les nixpkgs recents). Validation: pre-commit-check OK, eval hote OK.