### PR TITLE
fix: paperless systemd mount + nixflix password hash

### DIFF
--- a/apps/nixflix/default.nix
+++ b/apps/nixflix/default.nix
@@ -170,7 +170,7 @@ in
       password._secret = secrets."qbittorrent_password".path;
       serverConfig.Preferences.WebUI = {
         Username = "admin";
-        Password_PBKDF2 = "@ByteArray(VuvMO6udxeXWsDTCJiL4pw==:r5rg6+RmXxEsgUuFleFaxYQB2iUFL3QlFLa2/UBYu8aJ8xDYrLA5iD220MZp+713FgaTZybTCrc392rpoaCT0w==)";
+        Password_PBKDF2._secret = secrets."qbittorrent_password_pbkdf2".path;
       };
       serverConfig.BitTorrent.Session = {
         QueueingSystemEnabled = true;
@@ -303,6 +303,7 @@ in
         "jellyfin_admin_password"
         "seerr_api_key"
         "qbittorrent_password"
+        "qbittorrent_password_pbkdf2"
         "rutracker_username"
         "rutracker_password"
         "mullvad_wg"

--- a/apps/paperless-ngx/default.nix
+++ b/apps/paperless-ngx/default.nix
@@ -26,8 +26,8 @@ in
 
   systemd = {
     services.paperless-consumer = {
-      requires = [ "mnt-nfs-root.mount" ];
-      after = [ "mnt-nfs-root.mount" ];
+      requires = [ "mnt-nfs-WDC14_2.mount" ];
+      after = [ "mnt-nfs-WDC14_2.mount" ];
     };
 
     services.paperless-scheduler = {

--- a/secrets/nixflix.yaml
+++ b/secrets/nixflix.yaml
@@ -15,6 +15,7 @@ rutracker_password: ENC[AES256_GCM,data:lVgRWg1A96XKmmQEYGZLRV1Q/CU=,iv:DJWFRMdv
 mullvad_wg: ENC[AES256_GCM,data:23g8sL8N1pTDPD3u+3W+TSIZ6JewkYPFDb3h55w6bXQ30dJg4eEbrWd1Nyzdje+RbSPNGE/ByAruauMxY+57haHUFO1RK4ieZi3TaYbw3Gvfm73DV2pnZsynlmLqlRj2aD8bIVhqQbsYyDc1PfZr7zu1CVCVvy8TRKRT6I1RpFtbT5YNzfnW7Ut3h23B7wjMCP/bYNUuqdGwsiD6ng72dHnCgQUQhguWHbl2mKqroRNM7mPOuBeT7U7ehNoRL7gXqg+tNWvYFij37jzKT/R7clvZ9YFlJEwobGgY40m33FpLXbk0tzX/lHvzq4nT+1y36L+5s+2CCpEYT48rE1L7mfZxu7+6ALHzw5H+CzdNcHmTCCjLpEozmp4a0DJOQlknjUWVhg==,iv:ipc6g/1yTREKnDnpeeK4QcMB0jPDJ4dZftNUs3brRZc=,tag:cjzfa8AkU8RO1EJa5pY1LA==,type:str]
 slskd-env: ENC[AES256_GCM,data:yD+2CB00CJt3t+iK5u7FhX4I6FIqe1Z8MoPdlaL2WMJZ8wiWQnIGbma9xnxsdcUKiC+1A9BFjWIccBxHlhD87wZCF7xApHS4RS7ZEpI8PEiDKJJBHF7utxIL3F9L89xgYH34ckj5TXJDtaTmtBl0WOICKlLyBEP3eJCTuWXRaiHV+gKxP9Uqs7wP+IkcPA9l5lRLLLNtBhZ7k23C6yKF0lpStMyWvDBGm9B7+ob/9UTYbb4xzlTQxhm8iqN9mUnDQTM=,iv:xPMW+koBUEKt8p6cVaygunyRKOV8EBP4LuOjUAutHRs=,tag:gZHUHME+wsw63EA655GjwQ==,type:str]
 soularr-env: ENC[AES256_GCM,data:WzjecqfiQnYki0+gFx7HOAGbG0FnupgpOux1h4oGjCqfdklM1ZNCC4cCTU43MEoQVgQGBrt/BX37xJwuraue54xpfTugj1/beUwYO9cRVb4nzpvAFJ0DuXxK6KgfcA==,iv:V7Po4orCyWvIyhvgXCIUqQ3t2wFsNTKpOBHz9RP4uKw=,tag:SF4xh3YI0vgm6p8trmg29A==,type:str]
+qbittorrent_password_pbkdf2: ENC[AES256_GCM,data:qzt52eqbmdgg2DK4e/1/kR3yaN6ch3eR+Qodo4F7XaaxNJ0wNjer+iMVMjPWEZvhlfwbKnKHezGP6l0iOgNC6UvfBUGr3AQhS96uVtOr12m+lOpygrRyXQCMMkCCyCAJnOeLNsNaMblMiR4yd7WfpWpa0/NVK0S3s0bTs9k=,iv:a/BOKxNt5gnEftnKYotNp6X1KduIY9mbrHvnoagJzYA=,tag:vkeG3/iZUS1amnEkVXKRMw==,type:str]
 sops:
     age:
         - enc: |
@@ -35,7 +36,7 @@ sops:
             dh9l3+w475Kueia8TTLcNbBDhlbEC3FUbSVVoM2XJgAXicVkJSGK6g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1uj3yr6z6tpmx39pc0w9ch94hj8ucn6vt7fjaw8cj02uc5q6ee9hsnh4cw7
-    lastmodified: "2026-08-10T09:02:31Z"
-    mac: ENC[AES256_GCM,data:i2jkBknpEDUUmu/y4ebo2JNQ65mNMkEiCqeSVAAA5Q5rnBobrVU0aGmywq3le0k8VcdtnvttLS5mjBWuolQeDrRYyEyCE0vuxNI7FrIvEAorSxz6f6fBTh1uW5czB/2Qm1koLlgbCnn//LkOZ5rhn9dGu94yzqo2wBqK0WRy8pI=,iv:hyyhi7v5T0ea8uaBgiwvX+Z6gxAI9pkpbdax3LuZ8S8=,tag:f500t34xLqZY14ObMtoo/g==,type:str]
+    lastmodified: "2026-08-11T11:35:56Z"
+    mac: ENC[AES256_GCM,data:SbxZDAMtPFPRZPnSccNDSaP8kgK3fCP2J1Qyo9UQC88c6pFZ98Rfs96iBeU+ncPjGg2Smsky7n/t3WY2i1oOztBZSMGINUjm4oRmlarTyxf6/by81KH9lgyJa0gje3cmpqcc51opWAFC9bnN+zEtzbBerz7jQ4q5lEYDVb/drgo=,iv:b6/QQ3S3VQIzozWvp8W3DMEZL3CNYEJ9epvbq+/hszA=,tag:aMFoPKBM9MDbQgjI/Hr68Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Changes

### 1. Fix paperless-ngx systemd dependency
- **Before**: `paperless-consumer` depended on `mnt-nfs-root.mount` (jellyfin's mount)
- **After**: Correctly depends on `mnt-nfs-WDC14_2.mount` (paperless's actual NFS mount)

This was a latent bug that could cause paperless to fail to start if the jellyfin mount wasn't available, or succeed by accident if both services ran on the same host.

### 2. Move qBittorrent PBKDF2 hash to sops
- **Before**: Hardcoded PBKDF2 hash in `apps/nixflix/default.nix`
- **After**: Hash stored as `qbittorrent_password_pbkdf2` in sops secrets

## Required manual step
After merging, add the PBKDF2 hash to sops:
```bash
just secrets-edit
# Add: qbittorrent_password_pbkdf2: '@ByteArray(VuvMO6udxeXWsDTCJiL4pw==:r5rg6+RmXxEsgUuFleFaxYQB2iUFL3QlFLa2/UBYu8aJ8xDYrLA5iD220MZp+713FgaTZybTCrc392rpoaCT0w==)'
```

## Verification
- [x] Pre-commit checks pass
- [x] Paperless systemd unit now references correct mount
- [x] No hardcoded secrets in nix files