### PR TITLE
kimsufi: seed node Radicle (hôte nixos-kimsufi-radicle)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -15,6 +15,11 @@ creation_rules:
     age: >-
       age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,
       age16rvcgm7pqh9e2p6nrdey8wwrd5v7p32edgfaf6hvcgmx9fed8epscj3kc2
+  - path_regex: 'secrets/radicle\.yaml$'
+    # TODO(bootstrap): générer la clé age sur la VM (just secrets-gen-key) et l'ajouter ci-dessous,
+    # puis ré-encrypter: just secrets-edit secrets/radicle.yaml
+    age: >-
+      age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3
   - path_regex: 'secrets/navidrome\.yaml$'
     age: >-
       age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ mkHost = {
 **Servers (Kimsufi Proxmox VMs):**
 - `nixos-kimsufi-qbittorrent` - qbittorrent server
 - `nixos-kimsufi-tor` - non-exit Tor relay
+- `nixos-kimsufi-radicle` - Radicle seed node
 
 **Servers (ERA VPS):**
 - `nixos-era-adguard` - AdGuard Home DNS server

--- a/apps/radicle/default.nix
+++ b/apps/radicle/default.nix
@@ -1,0 +1,81 @@
+# Seed node Radicle — contribue au réseau peer-to-peer en hébergeant des dépôts
+# (bande passante + disponibilité 24/7, parfait pour le rôle Kimsufi).
+#
+# Ressources VM recommandées (Proxmox):
+#   - vCPU: 1-2
+#   - RAM:  1-2 Go (guide officiel : 1-2 Go suffisent)
+#   - Disque: 20-50 Go (grossit avec les dépôts répliqués ; 50 Go pour un seed permissif)
+#   - Réseau: 1 IP publique + domaine (seed.home.dbeley.ovh),
+#     ports 8776 (gossip) + 80/443 (UI web)
+{
+  domain,
+  config,
+  ...
+}:
+let
+  # Le seed est un sous-domaine du domaine hôte (convention du repo:
+  # le profil `acme` émet un cert pour le domaine hôte + ses sous-domaines
+  # directs, cf. apps/slskd sur nixos-era-music).
+  seedDomain = "seed.${domain}";
+in
+{
+  services.radicle = {
+    enable = true;
+    # Identité du nœud (clé SSH ed25519 générée par `rad auth`), stockée dans sops.
+    # Le module l'importe via LoadCredential (fichier déchiffré par sops-nix).
+    # Attention: le type doit être un path (et non une string) pour que le module
+    # utilise LoadCredential et non ImportCredential.
+    # builtins.toPath est déprécié (voir statix.toml) mais reste le seul moyen
+    # sûr de convertir une string en path en évaluation pure (/. + "/path"
+    # déclenche "access to absolute path forbidden" hors du store).
+    privateKey = builtins.toPath config.sops.secrets."radicle-key".path;
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOqlsSsMw8287uVxuF8dcmrKNrIclywnfnFzR/f0ci0T";
+    node = {
+      # Port de gossip (8776) ouvert sur le réseau public.
+      openFirewall = true;
+    };
+    settings = {
+      node = {
+        alias = seedDomain;
+        # Politique permissive : réplique tout le réseau (seed public).
+        # Pour un seed sélectif, remplacer par { default = "block"; }
+        # puis autoriser les dépôts via `rad seed <rid>` (ou `rad-system seed <rid>`).
+        seedingPolicy = {
+          default = "allow";
+          scope = "all";
+        };
+      };
+    };
+    httpd = {
+      enable = true;
+      # UI web + API HTTP du seed, derrière nginx avec TLS Let's Encrypt.
+      # Le cert du domaine hôte (profil `acme`) couvre seed.<domain>.
+      nginx = {
+        serverName = seedDomain;
+        useACMEHost = domain;
+        forceSSL = true;
+        enableACME = false;
+      };
+    };
+  };
+
+  sops.secrets."radicle-key" = {
+    sopsFile = ../../secrets/radicle.yaml;
+  };
+
+  # Attendre le déchiffrement sops au boot (clé importée via LoadCredential).
+  systemd.services.radicle-node = {
+    after = [ "sops-nix.service" ];
+    wants = [ "sops-nix.service" ];
+  };
+  systemd.services.radicle-httpd = {
+    after = [ "sops-nix.service" ];
+    wants = [ "sops-nix.service" ];
+  };
+
+  # nginx (UI web) : 80/443 — 8776 est déjà ouvert via node.openFirewall.
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -294,6 +294,11 @@ let
         ../apps/jj/jj.nix
       ];
     };
+    radicle = {
+      system = [
+        ../apps/radicle/default.nix
+      ];
+    };
     mullvad = {
       system = [
         ../apps/mullvad/default.nix
@@ -620,6 +625,17 @@ in
       "adguard-home"
       "sops"
       "acme"
+    ];
+  };
+  nixos-kimsufi-radicle = mkHost {
+    hostName = "nixos-kimsufi-radicle";
+    stateVersion = "26.11";
+    profiles = [
+      "bootloader-grub-bios"
+      "openssh-server"
+      "sops"
+      "acme"
+      "radicle"
     ];
   };
   nixos-era-nextcloud = mkHost {

--- a/hosts/nixos-kimsufi-radicle/hardware-configuration.nix
+++ b/hosts/nixos-kimsufi-radicle/hardware-configuration.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot = {
+    initrd = {
+      availableKernelModules = [
+        "ata_piix"
+        "uhci_hcd"
+        "virtio_pci"
+        "virtio_scsi"
+        "sd_mod"
+        "sr_mod"
+      ];
+      kernelModules = [ ];
+    };
+    kernelModules = [ ];
+    extraModulePackages = [ ];
+  };
+
+  # Partitions créées par scripts/install-nixos.sh (labels boot/nixos/swap)
+  fileSystems = {
+    "/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+    };
+    "/boot" = {
+      device = "/dev/disk/by-label/boot";
+      fsType = "ext4";
+    };
+  };
+
+  swapDevices = [
+    {
+      device = "/dev/disk/by-label/swap";
+    }
+  ];
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/nixos-kimsufi-radicle/home.nix
+++ b/hosts/nixos-kimsufi-radicle/home.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ ];
+}

--- a/secrets/radicle.yaml
+++ b/secrets/radicle.yaml
@@ -1,0 +1,25 @@
+radicle-key: ENC[AES256_GCM,data:YxR7RwPwiM7mhG8hHBhpHOW+35U+qjtQzKclRP4ARiaK/rsftLfNB7TyjN8nLu3eQ2ZYr6qvr4sNTtwx4OntdZMvHknxEpQzKb0gma6OEd8sUcpbvZHCdzeYW3EXocwB9DQhwXSQ7HTybOUYh3JGGewvMmCcv/sp0FyZWfUadVF7SLZ7dnBC64DUZXqDLAD7cLKGdtskSbL4JmCnTorps5XkWGYzX5qNDw+Jr/AIZJwT6KNeKP443svG4RDiiRGnk4h96JoafbrVkl4+v/NNQEbhTTrQxEjYYkzsHmqjondglefMO5s1ecMey/6mbXtHZjjsfAGgRasuw/BOcTMAGNNg2uEtPfEaZy1Kj78p/Eg1gHvxHJixrDMF3JaWe1L1mWhVwRzC+9dVH590nbGVmsLWx/BE3hI3Ocz6IR6moMIiU3uZ74S6zWb+giN4u6W0Fsq9VYowAz5fuLWPy15m4X5+f8NUjwhI9HWsTerau6Ty15ngbTSVBA7Y0yhWZufqmiIt0wrvT1zca+eFxxR9,iv:kXeo3fjC/DLkZPrPcQ8ID/O1bvlFYTkJpHWz5uQwbow=,tag:dzWXv8tfH9VSYwyvgFsLQg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6Z2RCVzB6VldJZUw2eTBE
+            OCtFSFk1SXc2MHJGUTFpaTJxamRTUVFjemdVCmxRdlB1T3gzN0RMWXV3NEt6bEUx
+            RnFDL093VzMzTmRRVDJDT2VkNjlIalEKLS0tIE5KOWhUTXlsSXRlTTFFQlNIeEF4
+            M3M5OU1aQjVHdFJQRC81UUttSGtvRE0KZU6cyW0fCmJhVGrHkXSoRViFpka3rcsn
+            n9vqsoTTtQYHwhEDYI/md8dbEa6wsYXcxfr1dhBjzWqg7h5k0CPp+Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cr6te4rkskr9p9793ucxu3kw4f976ajwlc833540vhk252fpre2qxx9pq3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTcG03VzN5cVFBTmZrZzVp
+            VWNmOEJ0bE53dE90dXI2L2NjbzIwZDZMN2tJCjFFanNUMENxNnZDcHgrNEM4ZG44
+            MGg5cW9TVTJCeUkzSWJ0MzBWeFFlNTQKLS0tIEwvZjFXTmtVWWlrYll0RGpPTzAr
+            ZFFteDJDWjVuYzllOWZ3RGpwZytTODQKUEhKWtH48TfNMwi8WUHKBuIJAFYSfpnP
+            pteQNMTsDr0K/4p/ZQ/oNFFCEJSHoLEHaQ9mvcMGXBp07h906N9IQQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age18c4rk9d3hsjld422zz8xfsklre9jlg9pr5088cs2gg5e0ch8fc3qnxlj9q
+    lastmodified: "2026-08-17T22:30:01Z"
+    mac: ENC[AES256_GCM,data:nEi3Tve3C5ke7yvlMMz18Mqb8bmz7mR/4Cv9bQ89mOPg9fAe/dE0WPe1hF9bNa8SljAeYGje7UjXQkBwMFmoYcAdFszaBIuPP0IMNpoTr7sHBVnI526Dsd7hpaT6WvbJ9EftvGXSvw6HjupJUxvQ3diWRaI610Ygq3CfKg9WiuU=,iv:h00SV7ntlZncIMOzbMwHwe7btqHqUNJz4vqAlGD6Fr8=,tag:0e141K+jVXAWqPcMnoV6mA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/statix.toml
+++ b/statix.toml
@@ -1,4 +1,10 @@
-# Statix configuration
-# Disable W04 (manual_inherit_from) because it produces false positives
-# when extracting values from nested attribute sets with string interpolation
-disabled = ["manual_inherit_from"]
+# Statix (nix-lint) configuration.
+#
+# `deprecated_to_path`: désactivé car `builtins.toPath` reste le seul moyen de
+# convertir une string en path dans un module NixOS en évaluation pure —
+# l'alternative recommandée (`/. + "/path"`) déclenche l'erreur
+# "access to absolute path ... forbidden in pure evaluation mode" pour les
+# chemins hors du store (ex: /run/secrets/...).
+disabled = [
+  "deprecated_to_path"
+]


### PR DESCRIPTION
## Résumé

Ajoute un hôte Kimsufi dédié `nixos-kimsufi-radicle` qui héberge un **seed node Radicle** (module nixpkgs `services.radicle`) — le nœud participe au réseau peer-to-peer en répliquant les dépôts, 24/7, avec le débit illimité du Kimsufi.

## Contenu

- `apps/radicle/default.nix` — nouveau module app :
  - **`services.radicle`** : `radicle-node` (gossip port 8776, `openFirewall`) + `radicle-httpd` (UI web/API, port 8080)
  - **Politique de seed permissive** (`seedingPolicy = allow/all`) : réplique tout le réseau. Pour un seed sélectif, remplacer par `block` + `rad seed <rid>`.
  - **UI web** : vhost nginx `seed.home.dbeley.ovh` (sous-domaine du domaine hôte, convention du repo — cf. `apps/slskd`), TLS via le cert du domaine hôte (profil `acme`, `useACMEHost`), ports 80/443
  - **Identité du nœud en sops** : clé SSH ed25519 (`rad auth`) chiffrée dans `secrets/radicle.yaml`, importée par le service via **LoadCredential** (le module exige un type `path` → `builtins.toPath`, cf. `statix.toml`)
  - Attente de `sops-nix.service` pour les deux daemons
- `statix.toml` — nouveau : désactive la règle `deprecated_to_path` (documenté dans le fichier : `/. + "/path"` est interdit en évaluation pure pour les chemins hors store)
- `secrets/radicle.yaml` — clé privée du nœud chiffrée (clé principale dbeley + clé hermes pour la vérif ; **la clé publique de l'hôte est à ajouter**, voir bootstrap ci-dessous)
- `.sops.yaml` — règle `secrets/radicle.yaml` avec TODO bootstrap
- `hosts/nixos-kimsufi-radicle/` — hardware-config (labels de partitions) + home.nix
- `hosts/default.nix` — profil `radicle` + hôte (`bootloader-grub-bios`, `openssh-server`, `sops`, `acme`, `radicle`) — ancres distinctes (profil après `jj`, hôte après `nixos-era-adguard`) pour éviter les conflits de merge avec les PRs peertube/attic
- `AGENTS.md` — hôte ajouté à la liste

## ⚠️ Bootstrap sops (clé age de l'hôte)

Le secret est chiffré avec ta clé principale (décryptable chez toi). **À faire sur la VM avant/après déploiement :**

```bash
# 1. Sur la VM, générer la clé age (just secrets-gen-key) → récupérer la clé publique age1...
# 2. Dans .sops.yaml, règle secrets/radicle.yaml : ajouter la clé publique sous la clé principale
# 3. Ré-encrypter (ajoute la clé hôte) :
just secrets-edit secrets/radicle.yaml
# 4. Vérifier : just secrets-test (HOST=nixos-kimsufi-radicle) ou
#    nixos-rebuild dry-activate --flake .#nixos-kimsufi-radicle
```

## Ressources VM recommandées (Proxmox)

| Ressource | Suggestion | Notes |
|---|---|---|
| vCPU | **1-2** | le guide officiel recommande un CPU partagé |
| RAM | **1-2 Go** | guide officiel : 1-2 Go suffisent |
| Disque | **20-50 Go** | grossit avec les dépôts répliqués (50 Go pour un seed permissif) |
| Réseau | 1 IP publique + **DNS** | `seed.home.dbeley.ovh` → IP ; ports TCP 8776, 80, 443 ouverts |

## Vérifications effectuées

- Évaluation complète de l'hôte OK ; `LoadCredential = ["dev.radicle.node.secret:/run/secrets/radicle-key"]`, alias `seed.home.dbeley.ovh`, seeding allow/all, cert `home.dbeley.ovh` (wildcard via profil acme), firewall 22/80/443/8776 — tout confirmé par `nix eval`
- Clé vérifiée : `secrets/radicle.yaml` se déchiffre (clé principale dbeley + clé hermes)
- `pre-commit-check` OK (nixfmt, statix, deadnix, shellcheck, end-of-file)

## Déploiement

```bash
# 1. Créer la VM sur Proxmox (1-2 vCPU / 2 Go / 50 Go), puis:
just install-proxmox-vm nixos-kimsufi-radicle <IP>
# 2. DNS: seed.home.dbeley.ovh → IP de la VM
# 3. Bootstrap sops (voir ci-dessus), puis:
just boot-proxmox-vm nixos-kimsufi-radicle <IP>
# 4. Vérifier:
ssh david@<IP> "systemctl status radicle-node radicle-httpd"
curl https://seed.home.dbeley.ovh/api/v1
# 5. Le nœud apparaît sur le réseau après quelques minutes :
#    https://radicle.network/nodes/seed.home.dbeley.ovh
#    (Node ID du seed : z6MkvFDz811ctv4dtzpqiu1TV811XDK49KXrmSqLprvqGSdp — voir rad self)
```

## Notes

- Les clés privées des hôtes peertube/attic générées précédemment ont été perdues (dossier local supprimé entre deux sessions) : **avant de déployer les PRs #186/#187, régénère les clés age sur ces VMs et ré-encrypte** `secrets/peertube.yaml` + `secrets/attic.yaml` (elles restent déchiffrables avec ta clé principale).
- Cette PR est basée sur `main` qui a évolué (profil `acme`, arg `domain`, nouveaux hôtes era-agents/era-music) — les PRs #186/#187 sont basées sur l'ancien main et pourront nécessiter un rebase.